### PR TITLE
Integration fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ To build the sdk you should have JDK 1.8, Android SDK (android-28) installed.
 ./gradlew check build assembleAndroidTest
 ```
 
-This will create two files, `snapyr-debug.aar` and `snapyr-release.aar`, in the directory `snapyr/build/output/aar`.
+This will create two files, `snapyr-debug.aar` and `snapyr-release.aar`, in the directory `snapyr/build/outputs/aar`.
 

--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ To build the sdk you should have JDK 1.8, Android SDK (android-28) installed.
 ./gradlew check build assembleAndroidTest
 ```
 
-Output .jar file can be found in analytics/build/libs folder
+This will create two files, `snapyr-debug.aar` and `snapyr-release.aar`, in the directory `snapyr/build/output/aar`.
 

--- a/snapyr/src/main/java/com/snapyr/sdk/ConnectionFactory.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/ConnectionFactory.java
@@ -38,7 +38,7 @@ public class ConnectionFactory {
 
     private static final int DEFAULT_READ_TIMEOUT_MILLIS = 20 * 1000; // 20s
     private static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 15 * 1000; // 15s
-    static final String USER_AGENT = "analytics-android/" + BuildConfig.VERSION_NAME;
+    static final String USER_AGENT = "snapyr-android/" + BuildConfig.VERSION_NAME;
 
     private String authorizationHeader(String writeKey) {
         return "Basic " + Base64.encodeToString((writeKey + ":").getBytes(), Base64.NO_WRAP);
@@ -54,7 +54,7 @@ public class ConnectionFactory {
      * https://dev-engine.snapyr.com/v1/import}.
      */
     public HttpURLConnection upload(String writeKey) throws IOException {
-        HttpURLConnection connection = openConnection("https://dev-engine.snapyr.com/v1/batch");
+        HttpURLConnection connection = openConnection("https://engine.snapyr.com/v1/batch");
         connection.setRequestProperty("Authorization", authorizationHeader(writeKey));
         // connection.setRequestProperty("Content-Encoding", "gzip");
         connection.setDoOutput(true);

--- a/snapyr/src/main/java/com/snapyr/sdk/Snapyr.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/Snapyr.java
@@ -300,7 +300,7 @@ public class Snapyr {
                                 new Runnable() {
                                     @Override
                                     public void run() {
-                                        performInitializeSnapyrIntegration();
+                                        performInitializeIntegrations(projectSettings);
                                     }
                                 });
                     }
@@ -1547,6 +1547,17 @@ public class Snapyr {
                                                 Map<String, Object> map =
                                                         cartographer.fromJson(
                                                                 Utils.buffer(connection.is));
+                                                if (!map.containsKey("integrations")) {
+                                                    map.put(
+                                                            "integrations",
+                                                            new ValueMap()
+                                                                    .putValue(
+                                                                            "Snapyr",
+                                                                            new ValueMap()
+                                                                                    .putValue(
+                                                                                            "apiKey",
+                                                                                            writeKey)));
+                                                }
                                                 return ProjectSettings.create(map);
                                             } finally {
                                                 Utils.closeQuietly(connection);
@@ -1629,16 +1640,6 @@ public class Snapyr {
             }
         }
         factories = null;
-    }
-
-    void performInitializeSnapyrIntegration() {
-        ValueMap snapyrSettings = new ValueMap();
-        snapyrSettings.put("Snapyr", new ValueMap());
-        snapyrSettings.getValueMap("Snapyr").putValue("apiKey", writeKey);
-
-        Integration integration = SnapyrIntegration.FACTORY.create(snapyrSettings, this);
-        integrations = new LinkedHashMap<>(1);
-        integrations.put("Snapyr", integration);
     }
 
     /** Runs the given operation on all integrations. */

--- a/snapyr/src/main/java/com/snapyr/sdk/Snapyr.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/Snapyr.java
@@ -270,16 +270,7 @@ public class Snapyr {
                         if (isNullOrEmpty(projectSettings)) {
                             // Backup mode - Enable the Snapyr integration and load the provided
                             // defaultProjectSettings
-                            // {
-                            //   ...defaultProjectSettings
-                            //   integrations: {
-                            //     ...defaultProjectSettings.integrations
-                            //     Snapyr: {
-                            //       ...defaultProjectSettings.integrations.Snapyr
-                            //       apiKey: "{writeKey}"
-                            //     }
-                            //   }
-                            // }
+
                             if (!defaultProjectSettings.containsKey("integrations")) {
                                 defaultProjectSettings.put("integrations", new ValueMap());
                             }
@@ -309,7 +300,7 @@ public class Snapyr {
                                 new Runnable() {
                                     @Override
                                     public void run() {
-                                        performInitializeIntegrations(projectSettings);
+                                        performInitializeSnapyrIntegration();
                                     }
                                 });
                     }
@@ -1638,6 +1629,16 @@ public class Snapyr {
             }
         }
         factories = null;
+    }
+
+    void performInitializeSnapyrIntegration() {
+        ValueMap snapyrSettings = new ValueMap();
+        snapyrSettings.put("Snapyr", new ValueMap());
+        snapyrSettings.getValueMap("Snapyr").putValue("apiKey", writeKey);
+
+        Integration integration = SnapyrIntegration.FACTORY.create(snapyrSettings, this);
+        integrations = new LinkedHashMap<>(1);
+        integrations.put("Snapyr", integration);
     }
 
     /** Runs the given operation on all integrations. */

--- a/snapyr/src/main/java/com/snapyr/sdk/integrations/Logger.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/integrations/Logger.java
@@ -32,7 +32,7 @@ import com.snapyr.sdk.Snapyr.LogLevel;
 
 /** An abstraction for logging messages. */
 public final class Logger {
-    private static final String DEFAULT_TAG = "Analytics";
+    private static final String DEFAULT_TAG = "Snapyr";
     public final LogLevel logLevel;
     private final String tag;
 

--- a/snapyr/src/test/java/com/snapyr/sdk/LoggerTest.kt
+++ b/snapyr/src/test/java/com/snapyr/sdk/LoggerTest.kt
@@ -119,7 +119,7 @@ class LoggerTest {
 
         assertThat(ShadowLog.getLogs()).containsExactly(
             LogItemBuilder()
-                .tag("Analytics-foo")
+                .tag("Snapyr-foo")
                 .type(Log.DEBUG)
                 .msg("some message with an argument")
                 .build()
@@ -128,7 +128,7 @@ class LoggerTest {
 
     class LogItemBuilder {
         private var type: Int = 0
-        private var tag: String = "Analytics"
+        private var tag: String = "Snapyr"
         private var msg: String = ""
         private var throwable: Throwable? = null
 


### PR DESCRIPTION
Enable Snapyr integration by default, as it is not part of the configs returned by the API.

Fix endpoint and a couple remnants from "Snapyr" rename