### PR TITLE
Deeplink fix

### DIFF
--- a/snapyr/src/main/java/com/snapyr/sdk/SnapyrIntegration.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/SnapyrIntegration.java
@@ -540,6 +540,15 @@ class SnapyrIntegration extends Integration<Void> {
 
         public static final boolean DEBUG_MODE = false;
 
+        public static void largeLog(String tag, String content) {
+            if (content.length() > 4000) {
+                Log.e(tag, content.substring(0, 4000));
+                largeLog(tag, content.substring(4000));
+            } else {
+                Log.e(tag, content);
+            }
+        }
+
         private final JsonWriter jsonWriter;
         /** Keep around for writing payloads as Strings. */
         private final BufferedWriter bufferedWriter;
@@ -618,7 +627,7 @@ class SnapyrIntegration extends Integration<Void> {
         public void close() throws IOException {
             if (DEBUG_MODE) {
                 Log.e("Snapyr", "Payload sent to Snapyr engine:");
-                Log.e("Snapyr", debugString.toString());
+                largeLog("Snapyr", debugString.toString());
             }
             jsonWriter.close();
         }

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
@@ -142,6 +142,14 @@ public class SnapyrNotificationHandler {
         if (deepLinkUrl != null) {
             Intent baseIntent = getLaunchIntent();
 
+            try {
+                Uri uri = Uri.parse(deepLinkUrl);
+                baseIntent.setData(uri);
+                baseIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            } catch (Exception e) {
+                Log.e("Snapyr", "showRemoteNotification: exception setting URI", e);
+            }
+
             baseIntent.putExtra(ACTION_ID_KEY, data.get(ACTION_ID_KEY));
             baseIntent.putExtra(NOTIF_DEEP_LINK_KEY, deepLinkUrl);
             baseIntent.putExtra(NOTIF_TOKEN_KEY, data.get(NOTIF_TOKEN_KEY));


### PR DESCRIPTION
Deep link url wasn't being set correctly on the notification after switching to lifecycle callbacks, so it was being dropped. This fixes that