### PR TITLE
Use UTF-8 on build VM

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=snapyr
 POM_DEVELOPER_NAME=Snapyr
 
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx1536m -Dfile.encoding=UTF-8
 
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
Fix for androidJavadocs errors in GH actions (hopefully)