### PR TITLE
Bug fixes from client feedback

### DIFF
--- a/snapyr/src/main/java/com/snapyr/sdk/internal/PushTemplate.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/internal/PushTemplate.java
@@ -79,10 +79,9 @@ public class PushTemplate {
         this.buttons = new ArrayList<>();
 
         ArrayList<Map<String, Object>> buttonsRaw = (ArrayList) src.get("actions");
-        buttonsRaw.forEach(
-                (v) -> {
-                    this.buttons.add(new ActionButton(v));
-                });
+        for (Map<String, Object> v : buttonsRaw) {
+            this.buttons.add(new ActionButton(v));
+        }
     }
 
     @RequiresApi(api = Build.VERSION_CODES.O)
@@ -91,11 +90,10 @@ public class PushTemplate {
                 (ArrayList<Map<String, Object>>) metadata.get("pushTemplates");
         HashMap<String, PushTemplate> parsed = new HashMap<String, PushTemplate>();
 
-        templates.forEach(
-                (v) -> {
-                    PushTemplate t = new PushTemplate(v);
-                    parsed.put(t.id, t);
-                });
+        for (Map<String, Object> v : templates) {
+            PushTemplate t = new PushTemplate(v);
+            parsed.put(t.id, t);
+        }
 
         return parsed;
     }

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
@@ -49,6 +49,7 @@ import com.snapyr.sdk.internal.PushTemplate;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
@@ -149,12 +150,10 @@ public class SnapyrNotificationHandler {
         PushTemplate pushTemplate = (PushTemplate) data.get(ACTION_BUTTONS_KEY);
         if (pushTemplate != null) {
             String token = (String) data.get(NOTIF_TOKEN_KEY);
-            pushTemplate
-                    .getButtons()
-                    .forEach(
-                            (button) -> {
-                                createActionButton(builder, notificationId, button, token);
-                            });
+            List<ActionButton> actionButtons = pushTemplate.getButtons();
+            for (ActionButton button : actionButtons) {
+                createActionButton(builder, notificationId, button, token);
+            }
         }
 
         // Image handling - fetch from URL

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
@@ -215,7 +215,8 @@ public class SnapyrNotificationHandler {
         builder.addAction(
                 R.drawable.ic_snapyr_logo_only,
                 template.title,
-                ts.getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT));
+                ts.getPendingIntent(
+                        0, PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT));
     }
 
     public void showSampleNotification() {

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
@@ -23,6 +23,8 @@
  */
 package com.snapyr.sdk.notifications;
 
+import static com.snapyr.sdk.internal.Utils.isNullOrEmpty;
+
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.PendingIntent;
@@ -160,7 +162,7 @@ public class SnapyrNotificationHandler {
         // TODO (@paulwsmith): move off-thread? (maybe not necessary; not part of main thread
         // anyway)
         String imageUrl = (String) data.get(NOTIF_IMAGE_URL_KEY);
-        if (imageUrl != null) {
+        if (!isNullOrEmpty(imageUrl)) {
             InputStream inputStream = null;
             Bitmap image = null;
             try {


### PR DESCRIPTION
Fixes to make SDK work more reliably without consuming app needing to change build settings or SDK target versions. (more than already required for our integration, at least)

### Convert lambdas to iterator for loops

Using lambdas means the consuming app needs to set their build settings to be compatible with Java 8. Taking them out so our SDK can be used without requiring changes on the consumer's side here.

TODO: see if we can use Java 8 stuff and desugar during our own build process?

### Fix for errors getting logged out when there is no imageUrl

The push payload sometimes (or maybe always?) includes `"imageUrl": ""`, i.e. empty string instead of null/undefined. Use `isNullOrEmpty` to skip more reliably, so there aren't errors being logged for no reason

### Add FLAG_IMMUTABLE to pending intent

So that consuming app doesn't get yelled at when using a min SDK target of 31 or higher, which enforces that FLAG_IMMUTABLE or FLAG_MUTABLE is specified here