### PR TITLE
Action button deeplink fix

### DIFF
--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrFirebaseMessagingService.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrFirebaseMessagingService.java
@@ -125,9 +125,9 @@ public class SnapyrFirebaseMessagingService extends FirebaseMessagingService {
 
         Snapyr sdkInstance = Snapyr.with(this);
         PushTemplate template = sdkInstance.getPushTemplates().get(templateId);
-        if ((template != null) && (template.getModified().after(modified))) {
-            // if the modified date in the push payload is older than the cached templates we're
-            // good to go and can just used the cached template value
+        if ((template != null) && (!template.getModified().before(modified))) {
+            // if the modified date in the push payload is equal to or older than the cached
+            // templates we're good to go and can just used the cached template value
             return template;
         }
 

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
@@ -213,12 +213,18 @@ public class SnapyrNotificationHandler {
         ts.addNextIntent(getLaunchIntent());
         ts.addNextIntent(trackIntent);
 
+        int flags = 0;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            flags = PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT;
+        } else {
+            flags = PendingIntent.FLAG_UPDATE_CURRENT;
+        }
+
         builder.addAction(
                 R.drawable.ic_snapyr_logo_only,
                 template.title,
-                ts.getPendingIntent(
-                        ++nextActionButtonCode,
-                        PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT));
+                ts.getPendingIntent(++nextActionButtonCode, flags));
     }
 
     public void showSampleNotification() {

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
@@ -86,6 +86,7 @@ public class SnapyrNotificationHandler {
             "Displays all Snapyr-managed notifications by default";
     public int defaultChannelImportance = NotificationManagerCompat.IMPORTANCE_HIGH;
     private int nextMessageId = 0;
+    private int nextActionButtonCode = 0;
 
     public SnapyrNotificationHandler(Context ctx) {
         context = ctx;
@@ -216,7 +217,8 @@ public class SnapyrNotificationHandler {
                 R.drawable.ic_snapyr_logo_only,
                 template.title,
                 ts.getPendingIntent(
-                        0, PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT));
+                        ++nextActionButtonCode,
+                        PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT));
     }
 
     public void showSampleNotification() {
@@ -232,13 +234,15 @@ public class SnapyrNotificationHandler {
         createActionButton(
                 builder,
                 notificationId,
-                new ActionButton("button_one", "button_one", "button_one", "snapyrsample://test"),
+                new ActionButton(
+                        "button_one", "button_one", "button_one", "snapyrsample://firsttest"),
                 "");
 
         createActionButton(
                 builder,
                 notificationId,
-                new ActionButton("button_two", "button_two", "button_two", ""),
+                new ActionButton(
+                        "button_two", "button_two", "button_two", "snapyrsample://secondtest"),
                 "");
 
         builder.setContentIntent(


### PR DESCRIPTION
Fixes action button deeplinks (https://snapyr.atlassian.net/browse/UNIC-141) and a couple minor things along the way.

[Fix for action button deeplinks all using the last button's value](https://github.com/snapyrautomation/snapyr-android-sdk/commit/d3dd68833a1a872ff04c87988d3691894c3f2061) 

The first parameter to TaskBuilder getPendingIntent is `requestCode`. Although this doesn't seem to be documented ANYWHERE, reusing the same request code causes future buttons to override the intent on previous buttons that used the same request code, causing every action button on a push notification to share the deeplink value of the last-registered button.

[Build fix - FLAG_IMMUTABLE only available on M or later](https://github.com/snapyrautomation/snapyr-android-sdk/commit/e054e4f7697d535d41132bd70baf31b0af851d26)

[Fix template modified triggering reload on every push](https://github.com/snapyrautomation/snapyr-android-sdk/commit/b2df61e8b7b2655b7ce6e8cb8af2402557cfdb96) 

If cached template data is up-to-date, the modified date will equal that on the push paylod. This was doing a > instead of >= check and so triggered a refresh 100% of the time