### PR TITLE
Fix error "Method removeObserver must be called on the main thread"

### DIFF
--- a/snapyr/src/main/java/com/snapyr/sdk/Snapyr.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/Snapyr.java
@@ -984,7 +984,19 @@ public class Snapyr {
         application.unregisterActivityLifecycleCallbacks(notificationLifecycleCallbacks);
         if (useNewLifecycleMethods) {
             // only unregister if feature is enabled
-            lifecycle.removeObserver(activityLifecycleCallback);
+            analyticsExecutor.submit(
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            HANDLER.post(
+                                    new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            lifecycle.removeObserver(activityLifecycleCallback);
+                                        }
+                                    });
+                        }
+                    });
         }
         // Only supplied by us for testing, so it's ok to shut it down. If we were to make this
         // public,
@@ -1183,8 +1195,7 @@ public class Snapyr {
          */
         public Builder flushQueueSize(int flushQueueSize) {
             if (flushQueueSize <= 0) {
-                throw new IllegalArgumentException(
-                        "flushQueueSize must be greater than or equal to zero.");
+                throw new IllegalArgumentException("flushQueueSize must be greater than zero.");
             }
             // 250 is a reasonably high number to trigger queue size flushes.
             // The queue may go over this size (as much as 1000), but you should flush much before

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
@@ -148,7 +148,8 @@ public class SnapyrNotificationHandler {
         ts.addNextIntent(getLaunchIntent());
         ts.addNextIntent(trackIntent);
 
-        builder.setContentIntent(ts.getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT));
+        int flags = getDefaultIntentFlags();
+        builder.setContentIntent(ts.getPendingIntent(0, flags));
 
         PushTemplate pushTemplate = (PushTemplate) data.get(ACTION_BUTTONS_KEY);
         if (pushTemplate != null) {
@@ -213,18 +214,23 @@ public class SnapyrNotificationHandler {
         ts.addNextIntent(getLaunchIntent());
         ts.addNextIntent(trackIntent);
 
-        int flags = 0;
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            flags = PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT;
-        } else {
-            flags = PendingIntent.FLAG_UPDATE_CURRENT;
-        }
+        int flags = getDefaultIntentFlags();
 
         builder.addAction(
                 R.drawable.ic_snapyr_logo_only,
                 template.title,
                 ts.getPendingIntent(++nextActionButtonCode, flags));
+    }
+
+    private int getDefaultIntentFlags() {
+        // Newer versions of Android require one of FLAG_MUTABLE or FLAG_IMMUTABLE to
+        // be included. FLAG_IMMUTABLE is the default as we don't currently support
+        // notifications with mutable content, such as inline-reply notifications
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT;
+        } else {
+            return PendingIntent.FLAG_UPDATE_CURRENT;
+        }
     }
 
     public void showSampleNotification() {


### PR DESCRIPTION
Fix error "Method removeObserver must be called on the main thread" when shutting down, at least on newer Android versions.