### PR TITLE
Fix exception on notification listener

### DIFF
--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationListener.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationListener.java
@@ -51,8 +51,6 @@ public class SnapyrNotificationListener extends Activity {
 
         // Dismiss source notification
         NotificationManagerCompat.from(this.getApplicationContext()).cancel(notificationId);
-        // Close notification drawer (so newly opened activity isn't behind anything)
-        this.getApplicationContext().sendBroadcast(new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS));
 
         if (!Utils.isNullOrEmpty(deepLink)) { // deeplink provided, respect it and advance
             Intent deepLinkIntent = new Intent();


### PR DESCRIPTION
Attempting to close notification drawer crashes due to permission error on later Android versions, which prevents notification impression/behavior tracks from being saved. Notification drawer dismissal seems to happen automatically anyway (see comments in TrackerUtil.java) so simply removing this to fix this issue.