### PR TITLE
In app fixes

### DIFF
--- a/snapyr/src/main/java/com/snapyr/sdk/http/ConnectionFactory.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/http/ConnectionFactory.java
@@ -95,11 +95,14 @@ public class ConnectionFactory {
         // Explicitly tell the server to not gzip the response.
         // Otherwise, HttpUrlsConnection will open a GzipInflater and not close it,
         connection.setRequestProperty("Accept-Encoding", "identity");
+        // NB "output" stream on URLConnection is for client sending request payload/body.
+        // "input" stream is for reading the response body back from the server.
+        // So enable request payload on POST by default, disable on GET by default.
         if (method == "POST") {
             connection.setDoOutput(true);
             connection.setChunkedStreamingMode(0);
         } else if (method == "GET") {
-            connection.setDoInput(false);
+            connection.setDoOutput(false);
         }
         return connection;
     }
@@ -119,6 +122,9 @@ public class ConnectionFactory {
         connection.setRequestProperty("Content-Type", "application/json");
         connection.setRequestProperty("User-Agent", USER_AGENT);
         connection.setRequestMethod(method);
+        // NB "output" stream on URLConnection is for client sending request payload/body.
+        // "input" stream is for reading the response body back from the server.
+        // We always want to read the response back, so enable "input"
         connection.setDoInput(true);
         return connection;
     }

--- a/snapyr/src/main/java/com/snapyr/sdk/inapp/requests/AckUserActionRequest.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/inapp/requests/AckUserActionRequest.java
@@ -40,6 +40,10 @@ public class AckUserActionRequest {
         HttpURLConnection conn = null;
         try {
             conn = ServiceFacade.getConnectionFactory().engineRequest(builtUrl, "POST");
+            // NB "output" stream on URLConnection is for client sending request payload/body.
+            // "input" stream is for reading the response body back from the server.
+            // These ack requests have no payload despite being POST
+            conn.setDoOutput(false);
             int responseCode = conn.getResponseCode();
             if (responseCode != 200) {
                 throw new HTTPException(responseCode, "failed to ack inapp message", "");

--- a/snapyr/src/main/java/com/snapyr/sdk/inapp/requests/GetUserActionsRequest.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/inapp/requests/GetUserActionsRequest.java
@@ -51,7 +51,6 @@ public class GetUserActionsRequest {
 
         try {
             conn = ServiceFacade.getConnectionFactory().engineRequest(builtUrl, "GET");
-            conn.setDoInput(false);
             int responseCode = conn.getResponseCode();
             if (responseCode != 200) {
                 throw new HTTPException(responseCode, "failed to fetch in-app messages", "");

--- a/snapyr/src/main/java/com/snapyr/sdk/internal/Utils.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/internal/Utils.java
@@ -550,10 +550,21 @@ public final class Utils {
     }
 
     public static class AnalyticsThreadFactory implements ThreadFactory {
+        private final AtomicInteger sequenceGenerator;
+        private final String threadPrefix;
+
+        public AnalyticsThreadFactory() {
+            this(THREAD_PREFIX);
+        }
+
+        public AnalyticsThreadFactory(String threadPrefix) {
+            sequenceGenerator = new AtomicInteger(1);
+            this.threadPrefix = threadPrefix;
+        }
 
         @SuppressWarnings("NullableProblems")
         public Thread newThread(Runnable r) {
-            return new AnalyticsThread(r);
+            return new AnalyticsThread(r, threadPrefix + sequenceGenerator.getAndIncrement());
         }
     }
 
@@ -561,8 +572,8 @@ public final class Utils {
 
         private static final AtomicInteger SEQUENCE_GENERATOR = new AtomicInteger(1);
 
-        public AnalyticsThread(Runnable r) {
-            super(r, THREAD_PREFIX + SEQUENCE_GENERATOR.getAndIncrement());
+        public AnalyticsThread(Runnable r, String s) {
+            super(r, s);
         }
 
         @Override

--- a/snapyr/src/test/java/com/snapyr/sdk/SnapyrTest.kt
+++ b/snapyr/src/test/java/com/snapyr/sdk/SnapyrTest.kt
@@ -134,6 +134,7 @@ open class SnapyrTest {
     fun makeAnalytics(): Snapyr {
         val created = Snapyr(
             application,
+            null,
             networkExecutor,
             traitsCache,
             snapyrContext,
@@ -508,6 +509,7 @@ open class SnapyrTest {
 
         var analytics = Snapyr(
             application,
+            null,
             networkExecutor,
             traitsCache,
             snapyrContext,
@@ -603,6 +605,7 @@ open class SnapyrTest {
 
         var analytics = Snapyr(
             application,
+            null,
             networkExecutor,
             traitsCache,
             snapyrContext,
@@ -669,6 +672,7 @@ open class SnapyrTest {
 
         var analytics = Snapyr(
             application,
+            null,
             networkExecutor,
             traitsCache,
             snapyrContext,
@@ -966,6 +970,7 @@ open class SnapyrTest {
 
             var analytics = Snapyr(
                 application,
+                null,
                 networkExecutor,
                 traitsCache,
                 snapyrContext,
@@ -1034,6 +1039,7 @@ open class SnapyrTest {
 
             var analytics = Snapyr(
                 application,
+                null,
                 networkExecutor,
                 traitsCache,
                 snapyrContext,
@@ -1104,6 +1110,7 @@ open class SnapyrTest {
 
             var analytics = Snapyr(
                 application,
+                null,
                 networkExecutor,
                 traitsCache,
                 snapyrContext,
@@ -1147,6 +1154,7 @@ open class SnapyrTest {
             val defaultProjectSettings = ValueMap()
             var analytics = Snapyr(
                 application,
+                null,
                 networkExecutor,
                 traitsCache,
                 snapyrContext,
@@ -1201,6 +1209,7 @@ open class SnapyrTest {
                 )
             var analytics = Snapyr(
                 application,
+                null,
                 networkExecutor,
                 traitsCache,
                 snapyrContext,
@@ -1257,6 +1266,7 @@ open class SnapyrTest {
         fun enableExperimentalNanosecondResolutionTimestamps() {
             var analytics = Snapyr(
                 application,
+                null,
                 networkExecutor,
                 traitsCache,
                 snapyrContext,


### PR DESCRIPTION
Fixes several bugs surfaced during in-app integration testing.

* Fix crash if Snapyr init'd outside of UI thread with an in-app config defined.
    In-app manager starts up a poller - this was defaulting to a handler that expected to init from within the UI thread.
    Moves to a thread pool that uses the same mechanism as the main batch queue handling code.
* Connection fixes for ack/queued action poll 
    Needed to swap around some of the setDoInput/setDoOutput flags to correctly configure requests. They are named confusingly
* Activity tracking fix for post-main-activity init
    Fixes bug in Snappy Bird test app - it initializes Snapyr after the main activity has started. This is similar to React Native logic and ensures the first/main activity is tracked by Snapyr in this case