### PR TITLE
Inapp public enums

### DIFF
--- a/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppActionType.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppActionType.java
@@ -1,0 +1,6 @@
+package com.snapyr.sdk.inapp;
+
+public enum InAppActionType {
+    ACTION_TYPE_CUSTOM,
+    ACTION_TYPE_OVERLAY,
+}

--- a/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppActionType.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppActionType.java
@@ -1,3 +1,26 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Segment.io, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.snapyr.sdk.inapp;
 
 public enum InAppActionType {

--- a/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppContentType.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppContentType.java
@@ -1,0 +1,6 @@
+package com.snapyr.sdk.inapp;
+
+public enum InAppContentType {
+    CONTENT_TYPE_JSON,
+    CONTENT_TYPE_HTML,
+}

--- a/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppContentType.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppContentType.java
@@ -1,3 +1,26 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Segment.io, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.snapyr.sdk.inapp;
 
 public enum InAppContentType {

--- a/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppMessage.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppMessage.java
@@ -30,16 +30,6 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-enum InAppActionType {
-    ACTION_TYPE_CUSTOM,
-    ACTION_TYPE_OVERLAY,
-}
-
-enum InAppContentType {
-    CONTENT_TYPE_JSON,
-    CONTENT_TYPE_HTML,
-}
-
 public class InAppMessage {
     public static final SimpleDateFormat Formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
     public final Date Timestamp;


### PR DESCRIPTION
Makes `InAppContentType`/`InAppActionType` public so consumers can use them to check incoming messages. 
