### PR TITLE
In-app ack fixes

### DIFF
--- a/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppActionProcessor.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppActionProcessor.java
@@ -26,7 +26,6 @@ package com.snapyr.sdk.inapp;
 import com.snapyr.sdk.inapp.webview.WebviewModalView;
 import com.snapyr.sdk.internal.Utils;
 import com.snapyr.sdk.services.ServiceFacade;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -36,21 +35,27 @@ public class InAppActionProcessor {
 
     InAppActionProcessor(InAppCallback userCallback) {
         this.userCallback = userCallback;
-        // Used to fire-and-forget user callback. Pool size of 1 means callbacks will fire sequentially (additional executions will be queued and processed in order by the executor automatically)
-        // This allows us to loop through our own list without the potential for user code to affect timing or interrupt processing due to errors
-        this.userCallbackExecutor = Executors.newFixedThreadPool(1, new Utils.AnalyticsThreadFactory("Snapyr-InAppUserCallback"));
+        // Used to fire-and-forget user callback. Pool size of 1 means callbacks will fire
+        // sequentially (additional executions will be queued and processed in order by the executor
+        // automatically)
+        // This allows us to loop through our own list without the potential for user code to affect
+        // timing or interrupt processing due to errors
+        this.userCallbackExecutor =
+                Executors.newFixedThreadPool(
+                        1, new Utils.AnalyticsThreadFactory("Snapyr-InAppUserCallback"));
     }
 
     public void process(InAppMessage message) {
         switch (message.ActionType) {
             case ACTION_TYPE_CUSTOM:
                 ServiceFacade.getLogger().info("dispatching user in-app action");
-                userCallbackExecutor.execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        userCallback.onAction(message);
-                    }
-                });
+                userCallbackExecutor.execute(
+                        new Runnable() {
+                            @Override
+                            public void run() {
+                                userCallback.onAction(message);
+                            }
+                        });
                 break;
             case ACTION_TYPE_OVERLAY:
                 try {

--- a/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppManager.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppManager.java
@@ -61,7 +61,8 @@ public class InAppManager implements InAppIFace {
                                 try {
                                     AckUserActionRequest.execute(
                                             message.UserId, message.ActionToken);
-                                    // Trigger user callbacks only after ack'ing, to prevent duplicate user callback triggers in the event of ack failure
+                                    // Trigger user callbacks only after ack'ing, to prevent
+                                    // duplicate user callback triggers in the event of ack failure
                                     actionProcessor.process(message);
                                 } catch (Exception e) {
                                     ServiceFacade.getLogger()
@@ -92,7 +93,8 @@ public class InAppManager implements InAppIFace {
     @Override
     public void dispatchPending(Context context) {
         if (!setDispatchInProgress(true)) {
-            // prevent requests from piling up; this function will be run again at the next polling interval
+            // prevent requests from piling up; this function will be run again at the next polling
+            // interval
             ServiceFacade.getLogger().info("in-app: dispatch already in progress; skipping poll");
             return;
         }
@@ -105,7 +107,9 @@ public class InAppManager implements InAppIFace {
                                 try {
                                     List<InAppMessage> polledActions =
                                             GetUserActionsRequest.execute(
-                                                    ServiceFacade.getSnapyrContext().traits().userId());
+                                                    ServiceFacade.getSnapyrContext()
+                                                            .traits()
+                                                            .userId());
 
                                     ServiceFacade.getLogger()
                                             .info("pulled " + polledActions.size() + " actions");

--- a/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppManager.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppManager.java
@@ -52,7 +52,6 @@ public class InAppManager implements InAppIFace {
     }
 
     private void processAndAck(InAppMessage message) {
-        actionProcessor.process(message);
         ServiceFacade.getNetworkExecutor()
                 .submit(
                         new Runnable() {
@@ -61,6 +60,8 @@ public class InAppManager implements InAppIFace {
                                 try {
                                     AckUserActionRequest.execute(
                                             message.UserId, message.ActionToken);
+                                    // Trigger user callbacks only after ack'ing, to prevent duplicate user callback triggers in the event of ack failure
+                                    actionProcessor.process(message);
                                 } catch (Exception e) {
                                     ServiceFacade.getLogger()
                                             .error(e, "failed to ack in-app action");


### PR DESCRIPTION
Send/confirm ack requests before triggering user callbacks; don't let user callback code affect processing. ack-then-callback is in line with other SDKs. Also moves calls to user-defined callbacks into their own thread, which prevents timing issues or exceptions from user code from interrupting our processing.

Also has some sync/timing improvements on the poller to prevent some problems I noticed with polling requests accumulating and rapid-firing when pausing in the step debugger (similar situations could possibly happen without the debugger; more details in commit message).