### PR TITLE
Move in-app tracking to shared Snapyr functions

### DIFF
--- a/snapyr/src/main/java/com/snapyr/sdk/Snapyr.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/Snapyr.java
@@ -757,6 +757,35 @@ public class Snapyr {
         track("snapyr.observation.event.Behavior", properties);
     }
 
+    public void trackInAppMessageImpression(final @Nullable String actionToken) {
+        assertNotShutdown();
+        Properties props =
+                new Properties()
+                        .putValue("actionToken", actionToken)
+                        .putValue("platform", "android");
+        track("snapyr.observation.event.Impression", props);
+    }
+
+    public void trackInAppMessageClick(
+            final @Nullable String actionToken, final @Nullable Properties properties) {
+        assertNotShutdown();
+        properties
+                .putValue("actionToken", actionToken)
+                .putValue("platform", "android")
+                .putValue("interactionType", "click");
+        track("snapyr.observation.event.Behavior", properties);
+    }
+
+    public void trackInAppMessageDismiss(final @Nullable String actionToken) {
+        assertNotShutdown();
+        Properties props =
+                new Properties()
+                        .putValue("actionToken", actionToken)
+                        .putValue("platform", "android")
+                        .putValue("interactionType", "dismiss");
+        track("snapyr.observation.event.Behavior", props);
+    }
+
     /**
      * The track method is how you record any actions your users perform. Each action is known by a
      * name, like 'Purchased a T-Shirt'. You can also record properties specific to those actions.

--- a/snapyr/src/main/java/com/snapyr/sdk/inapp/webview/WebviewModalView.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/inapp/webview/WebviewModalView.java
@@ -120,12 +120,7 @@ public class WebviewModalView extends FrameLayout {
     private void dismissPopup() {
         if (!wasInteractedWith) {
             // user didn't click a button, so send the dismissed
-            Properties props =
-                    new Properties()
-                            .putValue("actionToken", actionToken)
-                            .putValue("platform", "android")
-                            .putValue("interactionType", "dismiss");
-            snapyr.track("snapyr.observation.event.Behavior", props);
+            snapyr.trackInAppMessageDismiss(actionToken);
         }
 
         ServiceFacade.getCurrentActivity()
@@ -162,23 +157,15 @@ public class WebviewModalView extends FrameLayout {
                             @Override
                             public void onClick(String id, ValueMap parameters) {
                                 wasInteractedWith = true;
-                                Properties props =
-                                        new Properties(parameters)
-                                                .putValue("actionToken", actionToken)
-                                                .putValue("platform", "android")
-                                                .putValue("interactionType", "click");
-                                snapyr.track("snapyr.observation.event.Behavior", props);
+                                Properties props = new Properties(parameters);
+                                snapyr.trackInAppMessageClick(actionToken, props);
                                 // TODO: should we dismiss on click?
                                 dismissPopup();
                             }
 
                             @Override
                             public void onLoad(float clientHeight) {
-                                Properties props =
-                                        new Properties()
-                                                .putValue("actionToken", actionToken)
-                                                .putValue("platform", "android");
-                                snapyr.track("snapyr.observation.event.Impression", props);
+                                snapyr.trackInAppMessageImpression(actionToken);
                             }
                         }),
                 "snapyrMessageHandler");


### PR DESCRIPTION
Moves in-app tracking to shared, public Snapyr functions so users can manually track custom in-app messages. This facilitates the same for React Native SDK.

(https://snapyr.atlassian.net/browse/MEKA-458)