### PR TITLE
InAppContent.asValueMap - use map for JSON payload

### DIFF
--- a/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppContent.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppContent.java
@@ -103,7 +103,11 @@ public class InAppContent {
                                 (this.contentType == InAppContentType.CONTENT_TYPE_JSON)
                                         ? "json"
                                         : "html")
-                        .putValue("payload", this.rawPayload);
+                        .putValue(
+                                "payload",
+                                (this.contentType == InAppContentType.CONTENT_TYPE_JSON)
+                                        ? this.jsonContent
+                                        : this.htmlContent);
         return map;
     }
 


### PR DESCRIPTION
All SDKs are now passing this as a parsed map rather than a raw JSON string; this serializes fine and avoids needing to check and re-parse after receiving e.g. on the React Native side