### PR TITLE
In-app messaging - tweaks from documentation updates

### DIFF
--- a/snapyr/src/main/java/com/snapyr/sdk/Snapyr.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/Snapyr.java
@@ -745,19 +745,19 @@ public class Snapyr {
         track("snapyr.hidden.fcmTokenSet", new Properties().putValue("token", token));
     }
 
-    public void pushNotificationReceived(final @Nullable Properties properties) {
+    public void pushNotificationReceived(final @NonNull Properties properties) {
         assertNotShutdown();
         properties.putValue("platform", "android");
         track("snapyr.observation.event.Impression", properties);
     }
 
-    public void pushNotificationClicked(final @Nullable Properties properties) {
+    public void pushNotificationClicked(final @NonNull Properties properties) {
         assertNotShutdown();
         properties.putValue("platform", "android");
         track("snapyr.observation.event.Behavior", properties);
     }
 
-    public void trackInAppMessageImpression(final @Nullable String actionToken) {
+    public void trackInAppMessageImpression(final @NonNull String actionToken) {
         assertNotShutdown();
         Properties props =
                 new Properties()
@@ -766,8 +766,12 @@ public class Snapyr {
         track("snapyr.observation.event.Impression", props);
     }
 
+    public void trackInAppMessageClick(final @NonNull String actionToken) {
+        trackInAppMessageClick(actionToken, new Properties());
+    }
+
     public void trackInAppMessageClick(
-            final @Nullable String actionToken, final @Nullable Properties properties) {
+            final @NonNull String actionToken, final @NonNull Properties properties) {
         assertNotShutdown();
         properties
                 .putValue("actionToken", actionToken)
@@ -776,7 +780,7 @@ public class Snapyr {
         track("snapyr.observation.event.Behavior", properties);
     }
 
-    public void trackInAppMessageDismiss(final @Nullable String actionToken) {
+    public void trackInAppMessageDismiss(final @NonNull String actionToken) {
         assertNotShutdown();
         Properties props =
                 new Properties()

--- a/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppActionProcessor.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppActionProcessor.java
@@ -70,13 +70,13 @@ public class InAppActionProcessor {
     private void handleOverlay(InAppMessage message)
             throws InAppContent.IncorrectContentAccessException {
         switch (message.Content.getType()) {
-            case CONTENT_TYPE_JSON:
+            case PAYLOAD_TYPE_JSON:
                 ServiceFacade.getLogger().info("no action for json overlays currently");
                 break;
-            case CONTENT_TYPE_HTML:
+            case PAYLOAD_TYPE_HTML:
                 WebviewModalView.showPopup(
                         ServiceFacade.getCurrentActivity(),
-                        message.Content.getHtmlContent(),
+                        message.Content.getHtmlPayload(),
                         message.ActionToken);
                 break;
         }

--- a/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppContent.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppContent.java
@@ -28,71 +28,71 @@ import com.snapyr.sdk.services.Cartographer;
 import java.io.IOException;
 
 public class InAppContent {
-    private ValueMap jsonContent;
-    private InAppContentType contentType;
+    private ValueMap jsonPayload;
+    private InAppPayloadType payloadType;
     private String rawPayload;
-    private String htmlContent; // TODO: is there a better type for this? The HTML type
+    private String htmlPayload; // TODO: is there a better type for this? The HTML type
     // looks useless
 
     public InAppContent(ValueMap raw) throws InAppMessage.MalformedMessageException {
         if (raw == null) {
-            throw new InAppMessage.MalformedMessageException("content object is nul");
+            throw new InAppMessage.MalformedMessageException("content object is null");
         }
-        String contentType = raw.getString("payloadType");
-        if (contentType == null) {
+        String payloadType = raw.getString("payloadType");
+        if (payloadType == null) {
             throw new InAppMessage.MalformedMessageException("no payloadType key");
         }
 
-        Object content = raw.get("payload");
-        if (content == null) {
-            throw new InAppMessage.MalformedMessageException("no content");
+        Object payload = raw.get("payload");
+        if (payload == null) {
+            throw new InAppMessage.MalformedMessageException("no payload");
         }
 
-        this.rawPayload = (String) content;
+        this.rawPayload = (String) payload;
 
-        switch (contentType) {
+        switch (payloadType) {
             case "json":
-                this.contentType = InAppContentType.CONTENT_TYPE_JSON;
+                this.payloadType = InAppPayloadType.PAYLOAD_TYPE_JSON;
                 try {
-                    this.jsonContent =
-                            new ValueMap(Cartographer.INSTANCE.fromJson((String) content));
+                    this.jsonPayload =
+                            new ValueMap(Cartographer.INSTANCE.fromJson((String) payload));
                 } catch (IOException e) {
                     throw new InAppMessage.MalformedMessageException(
                             "failed to parse json content: " + e.getMessage());
                 }
-                if (this.jsonContent == null) {
+                if (this.jsonPayload == null) {
                     throw new InAppMessage.MalformedMessageException(
                             "unknown format for custom-json");
                 }
                 break;
             case "html":
-                this.contentType = InAppContentType.CONTENT_TYPE_HTML;
-                this.htmlContent = (String) content;
+                this.payloadType = InAppPayloadType.PAYLOAD_TYPE_HTML;
+                this.htmlPayload = (String) payload;
                 break;
             default:
-                if (this.jsonContent == null) {
+                if (this.jsonPayload == null) {
                     throw new InAppMessage.MalformedMessageException("unknown format for content");
                 }
                 break;
         }
     }
 
-    public InAppContentType getType() {
-        return this.contentType;
+    public InAppPayloadType getType() {
+        return this.payloadType;
     }
 
-    public ValueMap getJsonContent() throws IncorrectContentAccessException {
-        if (this.contentType != InAppContentType.CONTENT_TYPE_JSON) {
-            throw new IncorrectContentAccessException("content is not json");
+    public ValueMap getJsonPayload() throws IncorrectContentAccessException {
+        if (this.payloadType != InAppPayloadType.PAYLOAD_TYPE_JSON) {
+            throw new IncorrectContentAccessException("payload is not json");
         }
-        return this.jsonContent;
+        return this.jsonPayload;
     }
 
-    public String getHtmlContent() throws IncorrectContentAccessException {
-        if (this.contentType != InAppContentType.CONTENT_TYPE_HTML) {
-            throw new IncorrectContentAccessException("content is not html");
+    public String getHtmlPayload() throws IncorrectContentAccessException {
+        if (this.payloadType != InAppPayloadType.PAYLOAD_TYPE_HTML) {
+            throw new IncorrectContentAccessException("payload is not html");
         }
-        return this.htmlContent;
+        return this.htmlPayload;
     }
 
     public ValueMap asValueMap() {
@@ -100,14 +100,14 @@ public class InAppContent {
                 new ValueMap()
                         .putValue(
                                 "payloadType",
-                                (this.contentType == InAppContentType.CONTENT_TYPE_JSON)
+                                (this.payloadType == InAppPayloadType.PAYLOAD_TYPE_JSON)
                                         ? "json"
                                         : "html")
                         .putValue(
                                 "payload",
-                                (this.contentType == InAppContentType.CONTENT_TYPE_JSON)
-                                        ? this.jsonContent
-                                        : this.htmlContent);
+                                (this.payloadType == InAppPayloadType.PAYLOAD_TYPE_JSON)
+                                        ? this.jsonPayload
+                                        : this.htmlPayload);
         return map;
     }
 

--- a/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppMessage.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppMessage.java
@@ -49,13 +49,13 @@ public class InAppMessage {
             throw new MalformedMessageException("malformed timestamp");
         }
 
-        String contentType = action.getString("actionType");
-        if (Utils.isNullOrEmpty(contentType)) {
+        String actionType = action.getString("actionType");
+        if (Utils.isNullOrEmpty(actionType)) {
             throw new MalformedMessageException("missing actionType in action");
         }
         this.UserId = action.getString("userId");
 
-        switch (contentType) {
+        switch (actionType) {
             case "custom":
                 this.ActionType = InAppActionType.ACTION_TYPE_CUSTOM;
                 break;
@@ -63,7 +63,7 @@ public class InAppMessage {
                 this.ActionType = InAppActionType.ACTION_TYPE_OVERLAY;
                 break;
             default:
-                throw new MalformedMessageException("unknown content type: " + contentType);
+                throw new MalformedMessageException("unknown content type: " + actionType);
         }
 
         this.ActionToken = action.getString("actionToken");

--- a/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppPayloadType.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/inapp/InAppPayloadType.java
@@ -23,7 +23,7 @@
  */
 package com.snapyr.sdk.inapp;
 
-public enum InAppContentType {
-    CONTENT_TYPE_JSON,
-    CONTENT_TYPE_HTML,
+public enum InAppPayloadType {
+    PAYLOAD_TYPE_JSON,
+    PAYLOAD_TYPE_HTML,
 }

--- a/snapyr/src/test/java/com/snapyr/sdk/inapp/InAppTest.kt
+++ b/snapyr/src/test/java/com/snapyr/sdk/inapp/InAppTest.kt
@@ -85,8 +85,8 @@ class InAppTest {
                     check(it.Timestamp == InAppMessage.Formatter.parse("2022-08-31T17:15:30.135145417Z"))
                     check(it.UserId == "Brian")
                     check(it.ActionType == InAppActionType.ACTION_TYPE_CUSTOM)
-                    check(it.Content.type == InAppContentType.CONTENT_TYPE_JSON)
-                    check(it.Content.jsonContent != null)
+                    check(it.Content.type == InAppPayloadType.PAYLOAD_TYPE_JSON)
+                    check(it.Content.jsonPayload != null)
                     callbackSemaphore.release()
                 },
             context


### PR DESCRIPTION
* Small consistency tweaks after going through documentation updates for several SDKs
Updates naming to be consistent with other SDKs and other parts of the system - InAppContent has a `payload` and `payloadType` rather than `content` and `contentType`.
* Correct nullability on tracking method params 
    * Fix params that were NOT nullable, but marked as nullable, to be correct.
    * Also adds overload method for `trackInAppMessageClick` so that additional properties are optional, for user convenience and consistency with other SDKs.