### PR TITLE
Gradle publish fixes

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,20 +1,21 @@
 Releasing
 =========
 
- 1. Create a new branch called `release/X.Y.Z`
- 2. `git checkout -b release/X.Y.Z`
- 3. Change the version in `gradle.properties` to your desired release version
- 4. Update the `CHANGELOG.md` for the impending release.
- 5. `git commit -am "Create release X.Y.Z."` (where X.Y.Z is the new version)
- 6. `git push`
- 7. Merge release/X.Y.Z back to main branch
+1. Create a new branch called `release/X.Y.Z`
+1. `git checkout -b release/X.Y.Z`
+1. Change the version in `gradle.properties` to your desired release version
+1. `git commit -am "Create release X.Y.Z."` (where X.Y.Z is the new version)
+1. Create a tag, which will also be used for the GitHub release
+1. `git tag -a vX.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the new version)
+1. `git push && git push --tags`
+1. Merge release/X.Y.Z back to main branch
 
 Example (stable release)
 ========
- 1. Current VERSION_NAME in `gradle.properties` = 0.10.0
- 2. `git checkout -b release/0.10.1`
- 3. Change VERSION_NAME = 0.10.1 (next higher version)
- 4. Update CHANGELOG.md
- 5. `git commit -am "Create release 0.10.1"`
- 6. `git push`
- 7. Merge release/0.10.1 back to main branch
+1. Current VERSION_NAME in `gradle.properties` = 0.10.0
+1. `git checkout -b release/0.10.1`
+1. Change VERSION_NAME = 0.10.1 (next higher version)
+1. `git commit -am "Create release 0.10.1"`
+1. `git tag -a v0.10.1 -m "Version 0.10.1"`
+1. `git push && git push --tags`
+1. Merge release/0.10.1 back to main branch

--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,9 @@ buildscript {
     repositories {
         mavenCentral()
         google()
-        jcenter()
         maven {
             url 'https://plugins.gradle.org/m2/'
         }
-        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     }
 
     dependencies {
@@ -34,7 +32,6 @@ allprojects {
         repositories {
             mavenCentral()
             google()
-            jcenter()
         }
     }
 
@@ -43,7 +40,6 @@ allprojects {
     repositories {
         mavenCentral()
         google()
-        jcenter()
     }
 
     group = GROUP

--- a/gradle/mvn-publish.gradle
+++ b/gradle/mvn-publish.gradle
@@ -21,6 +21,13 @@ task androidJavadocs(type: Javadoc) {
     android.libraryVariants.all { variant ->
         if (variant.name == 'release') {
             owner.classpath += variant.javaCompileProvider.get().classpath
+            // Add generated BuildConfig to classpath - fixes javadoc errors like
+            // "error: cannot find symbol import com.snapyr.sdk.core.BuildConfig;"
+            owner.classpath += files(project.buildDir.absolutePath + "/generated/source/buildConfig/release")
+        } else if (variant.name == 'debug') {
+            // Add generated BuildConfig to classpath - fixes javadoc errors like
+            // "error: cannot find symbol import com.snapyr.sdk.core.BuildConfig;"
+            owner.classpath += files(project.buildDir.absolutePath + "/generated/source/buildConfig/debug")
         }
     }
     exclude '**/R.html', '**/R.*.html', '**/index.html'

--- a/snapyr/build.gradle
+++ b/snapyr/build.gradle
@@ -47,6 +47,5 @@ dependencies {
 apply from: rootProject.file('gradle/mvn-publish.gradle')
 
 repositories {
-	maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
 	mavenCentral()
 }

--- a/snapyr/src/main/java/com/snapyr/sdk/http/BatchUploadQueue.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/http/BatchUploadQueue.java
@@ -60,7 +60,7 @@ public class BatchUploadQueue {
      * QueueFile's 2GB limit.
      */
     public static final int MAX_QUEUE_SIZE = 1000;
-    /** Our servers only accept payloads < 32KB. */
+    /** Our servers only accept payloads up to 32KB. */
     public static final int MAX_PAYLOAD_SIZE = 32000; // 32KB.
 
     private static final String SNAPYR_THREAD_NAME = Utils.THREAD_PREFIX + "SnapyrDispatcher";

--- a/snapyr/src/main/java/com/snapyr/sdk/http/BatchUploadRequest.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/http/BatchUploadRequest.java
@@ -40,9 +40,9 @@ import java.util.Date;
 /** A wrapper that emits a JSON formatted batch payload to the underlying writer. */
 public class BatchUploadRequest implements Closeable, BatchQueue.ElementVisitor {
     /**
-     * Our servers only accept batches < 500KB. This limit is 475KB to account for extra data that
-     * is not present in payloads themselves, but is added later, such as {@code sentAt}, {@code
-     * integrations} and other json tokens.
+     * Our servers only accept batches up to 500KB. This limit is 475KB to account for extra data
+     * that is not present in payloads themselves, but is added later, such as {@code sentAt},
+     * {@code integrations} and other json tokens.
      */
     @Private static final int MAX_BATCH_SIZE = 475000; // 475KB.
 


### PR DESCRIPTION
* Fix Javadoc errors on gradle publish 
    * Add generated BuildConfig to classpath - fixes javadoc errors like `error: cannot find symbol import  com.snapyr.sdk.core.BuildConfig;`
    * Remove `<` character in javadoc comments that the plugin complains about
* Remove unused/sunsetted bintray and jcenter
Both of these were sunsetted in 2021. Including these repositories in our gradle files appears to have had no ill effect, but they didn't do anything, so cleaning up.
* Update release instructions to include tagging