### PR TITLE
Push notification tracking/launch behavior improvements

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 GROUP=com.snapyr.sdk.android
 
 VERSION_CODE=1022
-VERSION_NAME=1.2.2-beta1
+VERSION_NAME=1.2.2-beta2
 
 POM_NAME=Snapyr for Android
 POM_DESCRIPTION=Snapyr Android SDK

--- a/snapyr-samples/sample/src/main/java/com/snapyr/sdk/sample/SampleApp.java
+++ b/snapyr-samples/sample/src/main/java/com/snapyr/sdk/sample/SampleApp.java
@@ -61,9 +61,9 @@ public class SampleApp extends Application {
                                     public void onVmViolation(Violation v) {
                                         // This catches leaks in our code that would have propagated
                                         // to
-                                    // client code in the wild. If you want to be really careful
-                                    // uncomment the penaltyDeath line above --BS
-                                    Log.e(
+                                        // client code in the wild. If you want to be really careful
+                                        // uncomment the penaltyDeath line above --BS
+                                        Log.e(
                                                 v.getLocalizedMessage(),
                                                 String.valueOf(v.getCause().getStackTrace()));
                                     }

--- a/snapyr-samples/sample/src/main/java/com/snapyr/sdk/sample/SampleApp.java
+++ b/snapyr-samples/sample/src/main/java/com/snapyr/sdk/sample/SampleApp.java
@@ -56,13 +56,17 @@ public class SampleApp extends Application {
                         // .penaltyDeath()
                         .penaltyListener(
                                 Executors.newSingleThreadExecutor(),
-                                (Violation var1) -> {
-                                    // This catches leaks in our code that would have propagated to
+                                new StrictMode.OnVmViolationListener() {
+                                    @Override
+                                    public void onVmViolation(Violation v) {
+                                        // This catches leaks in our code that would have propagated
+                                        // to
                                     // client code in the wild. If you want to be really careful
                                     // uncomment the penaltyDeath line above --BS
                                     Log.e(
-                                            var1.getLocalizedMessage(),
-                                            String.valueOf(var1.getCause().getStackTrace()));
+                                                v.getLocalizedMessage(),
+                                                String.valueOf(v.getCause().getStackTrace()));
+                                    }
                                 })
                         .build());
 

--- a/snapyr-samples/sample/src/main/res/layout/activity_main.xml
+++ b/snapyr-samples/sample/src/main/res/layout/activity_main.xml
@@ -84,6 +84,15 @@
             android:layout_height="wrap_content"
             android:text="@string/flush" />
 
+        <TextView
+            android:id="@+id/event_log"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:paddingLeft="8dp"
+            android:textSize="16dp"
+            android:bufferType="editable" />
+
     </LinearLayout>
 
 </ScrollView>

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrFirebaseMessagingService.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrFirebaseMessagingService.java
@@ -110,7 +110,8 @@ public class SnapyrFirebaseMessagingService extends FirebaseMessagingService {
 
     @RequiresApi(api = Build.VERSION_CODES.O)
     private PushTemplate processPushTemplate(@NonNull ValueMap templateObject, Snapyr sdkInstance) {
-        String templateRaw = templateObject.get("pushTemplate").toString();
+        String templateRaw =
+                templateObject.get(SnapyrNotificationHandler.NOTIF_TEMPLATE_KEY).toString();
         String templateId = null;
         Date modified = null;
         try {

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
@@ -30,11 +30,9 @@ import android.app.NotificationChannel;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.graphics.Color;
 import android.os.Build;
 import android.util.Log;
 import androidx.annotation.NonNull;
@@ -137,7 +135,6 @@ public class SnapyrNotificationHandler {
                 .setContentTitle((String) data.get(NOTIF_TITLE_KEY))
                 .setContentText((String) data.get(NOTIF_CONTENT_KEY))
                 .setSubText((String) data.get(NOTIF_SUBTITLE_KEY))
-                .setColor(Color.BLUE) // TODO (@paulwsmith): make configurable
                 .setAutoCancel(true); // true means notification auto dismissed after tapping. TODO
 
         Intent trackIntent = new Intent(applicationContext, SnapyrNotificationListener.class);

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
@@ -28,7 +28,6 @@ import static com.snapyr.sdk.internal.Utils.isNullOrEmpty;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.PendingIntent;
-import android.app.TaskStackBuilder;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -92,7 +91,7 @@ public class SnapyrNotificationHandler {
             "Displays all Snapyr-managed notifications by default";
     public int defaultChannelImportance = NotificationManagerCompat.IMPORTANCE_HIGH;
     private int nextMessageId = 0;
-    private int nextActionButtonCode = 0;
+    private int nextIntentRequestCode = 0;
 
     public SnapyrNotificationHandler(Context ctx) {
         context = ctx;
@@ -103,7 +102,6 @@ public class SnapyrNotificationHandler {
                 defaultChannelName,
                 defaultChannelDescription,
                 defaultChannelImportance);
-        getLaunchIntent();
     }
 
     public void registerChannel(String channelId, String name, String description, int importance) {
@@ -142,20 +140,23 @@ public class SnapyrNotificationHandler {
                 .setColor(Color.BLUE) // TODO (@paulwsmith): make configurable
                 .setAutoCancel(true); // true means notification auto dismissed after tapping. TODO
 
-        TaskStackBuilder ts = TaskStackBuilder.create(this.context);
-
-        Intent trackIntent = new Intent(this.context, SnapyrNotificationListener.class);
-        trackIntent.setAction(NOTIFICATION_ACTION);
+        Intent trackIntent = new Intent(applicationContext, SnapyrNotificationListener.class);
         trackIntent.putExtra(ACTION_ID_KEY, (String) data.get(ACTION_ID_KEY));
         trackIntent.putExtra(ACTION_DEEP_LINK_KEY, (String) data.get(NOTIF_DEEP_LINK_KEY));
         trackIntent.putExtra(NOTIFICATION_ID, notificationId);
         trackIntent.putExtra(NOTIF_TOKEN_KEY, (String) data.get(NOTIF_TOKEN_KEY));
 
-        ts.addNextIntent(getLaunchIntent());
-        ts.addNextIntent(trackIntent);
+        trackIntent.addFlags(
+                0
+                        | Intent.FLAG_ACTIVITY_SINGLE_TOP
+                        | Intent.FLAG_ACTIVITY_CLEAR_TOP
+                        | Intent.FLAG_ACTIVITY_NO_HISTORY
+                        | Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
 
-        int flags = getDefaultIntentFlags();
-        builder.setContentIntent(ts.getPendingIntent(0, flags));
+        int flags = getDefaultPendingIntentFlags();
+        builder.setContentIntent(
+                PendingIntent.getActivity(
+                        this.context, ++nextIntentRequestCode, trackIntent, flags));
 
         PushTemplate pushTemplate = (PushTemplate) data.get(ACTION_BUTTONS_KEY);
         if (pushTemplate != null) {
@@ -228,24 +229,6 @@ public class SnapyrNotificationHandler {
         return result;
     }
 
-    private Intent getLaunchIntent() {
-        try {
-            PackageManager pm = applicationContext.getPackageManager();
-            Intent launchIntent = pm.getLaunchIntentForPackage(applicationContext.getPackageName());
-            if (launchIntent == null) {
-                // No launch intent specified / found for this app. Default to ACTION_MAIN
-                launchIntent = new Intent(Intent.ACTION_MAIN);
-                launchIntent.addFlags(
-                        Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-                launchIntent.setPackage(applicationContext.getPackageName());
-            }
-            return launchIntent;
-        } catch (Exception e) {
-            Log.e("Snapyr", "Could not get launch intent", e);
-            return new Intent(Intent.ACTION_MAIN);
-        }
-    }
-
     private void createActionButton(
             NotificationCompat.Builder builder,
             int notificationId,
@@ -258,19 +241,15 @@ public class SnapyrNotificationHandler {
         trackIntent.putExtra(NOTIFICATION_ID, notificationId);
         trackIntent.putExtra(NOTIF_TOKEN_KEY, actionToken);
 
-        TaskStackBuilder ts = TaskStackBuilder.create(this.context);
-        ts.addNextIntent(getLaunchIntent());
-        ts.addNextIntent(trackIntent);
+        int flags = getDefaultPendingIntentFlags();
+        PendingIntent pendingIntent =
+                PendingIntent.getActivity(
+                        this.context, ++nextIntentRequestCode, trackIntent, flags);
 
-        int flags = getDefaultIntentFlags();
-
-        builder.addAction(
-                R.drawable.ic_snapyr_logo_only,
-                template.title,
-                ts.getPendingIntent(++nextActionButtonCode, flags));
+        builder.addAction(R.drawable.ic_snapyr_logo_only, template.title, pendingIntent);
     }
 
-    private int getDefaultIntentFlags() {
+    private int getDefaultPendingIntentFlags() {
         // Newer versions of Android require one of FLAG_MUTABLE or FLAG_IMMUTABLE to
         // be included. FLAG_IMMUTABLE is the default as we don't currently support
         // notifications with mutable content, such as inline-reply notifications


### PR DESCRIPTION
### Push notification tracking/launch behavior improvements 
We were using TaskStackBuilder, which is generally recommended for setting up the activity stack for a notification, but it makes it harder to control the opening behavior with our tracking activity in the middle.

The previous setup was causing a full new activity to be launched even if the activity was in `singleTask` (or other "single...") launch mode and already open.

Moves some of the responsibility for opening the "real" activity to the tracking activity, which can set flags on the intent to improve this behavior.

In this update, if there is no deep link URL, the same activity that was already open should simply come to the foreground (note that this does not trigger any lifecycle calls on the activity, so while Snapyr tracking still runs here, there is not an obvious way for user code to know that it was brought to the foreground from a notification tap at this time).

If there is a deep link URL, a new version of the activity will be launched with that data, which is the generally expected behavior.

For a `singleTask` activity, the task will be brought to the foreground and the `onNewIntent()` method will be triggered with the new data from the notification.

### Bundled test app updates for testing
* Adds a visual text log beneath the UI widgets so it's easier to keep track of what's happening
* Adds `onNewIntent()` and some additional logging to show behavior of activity launch/update
* Updates `showSampleNotification()` to build a proper notification object and run the real `showRemoteNotification()` method, so sample notifications are a more reliable test of the real notification code