### PR TITLE
Notification - immediate flush fix

### DIFF
--- a/snapyr/src/main/java/com/snapyr/sdk/Snapyr.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/Snapyr.java
@@ -982,7 +982,13 @@ public class Snapyr {
         if (shutdown) {
             throw new IllegalStateException("Cannot enqueue messages after client is shutdown.");
         }
-        sendQueue.flush();
+        analyticsExecutor.submit(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        sendQueue.flush();
+                    }
+                });
     }
 
     /** Get the {@link SnapyrContext} used by this instance. */


### PR DESCRIPTION
Track/identify/etc. calls add events to the queue on executor, but flush was calling sendQueue.flush directly/immediately. That could result in sendQueue.flush being run before the event reached the queue, causing the flush to miss that event.

This moves the sendQueue.flush call to the executor as well, so it will run sequentially after any previously-called event queuing methods.

Fixes push tracking events not making it to back end when a notification was tapped after the application was closed