### PR TITLE
Push notification event broadcast

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         classpath 'com.google.gms:google-services:4.3.5'
         classpath 'com.vanniktech:gradle-android-junit-jacoco-plugin:0.16.0'
         classpath 'com.diffplug.spotless:spotless-plugin-gradle:3.29.0'
-        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:2.0.0'
+        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:3.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.22.0"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-apply from: rootProject.file('gradle/versioning.gradle')
+apply from: project.file('gradle/versioning.gradle')
 
 buildscript {
     ext.kotlin_version = '1.4.0'
@@ -67,4 +67,6 @@ ext.deps = [
     supportAnnotations: 'androidx.annotation:annotation:1.1.0'
 ]
 
-apply from: rootProject.file('gradle/promote.gradle')
+if (project == rootProject) {
+    apply from: rootProject.file('gradle/promote.gradle')
+}

--- a/gradle/android.gradle
+++ b/gradle/android.gradle
@@ -1,17 +1,25 @@
+// See snapyrRootProject in snapyr/build.gradle for more info
+ext {
+    snapyrRootProject = project.findProject(":snapyr-root")
+    if (snapyrRootProject == null) {
+        snapyrRootProject = rootProject
+    }
+}
+
 apply plugin: 'com.diffplug.gradle.spotless'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion snapyrRootProject.ext.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode rootProject.ext.versionCode
-        versionName rootProject.ext.versionName
+        minSdkVersion snapyrRootProject.ext.minSdkVersion
+        targetSdkVersion snapyrRootProject.ext.targetSdkVersion
+        versionCode snapyrRootProject.ext.versionCode
+        versionName snapyrRootProject.ext.versionName
     }
 
     dexOptions {
-        preDexLibraries rootProject.ext.preDexLibraries
+        preDexLibraries snapyrRootProject.ext.preDexLibraries
     }
 
     packagingOptions {
@@ -25,8 +33,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility rootProject.ext.sourceCompatibilityVersion
-        targetCompatibility rootProject.ext.targetCompatibilityVersion
+        sourceCompatibility snapyrRootProject.ext.sourceCompatibilityVersion
+        targetCompatibility snapyrRootProject.ext.targetCompatibilityVersion
     }
 
     lintOptions {
@@ -63,7 +71,7 @@ spotless {
 }
 
 def getLicenseText() {
-    def rawTextLines = rootProject.file('LICENSE.md').text.split('\n')
+    def rawTextLines = snapyrRootProject.file('LICENSE.md').text.split('\n')
     def text = ""
     for (def line : rawTextLines) {
         if (line.trim().length() == 0) {

--- a/gradle/mvn-publish.gradle
+++ b/gradle/mvn-publish.gradle
@@ -118,7 +118,7 @@ signing {
 }
 
 afterEvaluate {
-    androidJavadocs.classpath += project.android.libraryVariants.toList().first().javaCompile.classpath
+    androidJavadocs.classpath += project.android.libraryVariants.toList().first().javaCompileProvider.get().classpath
 }
 
 publish.dependsOn build

--- a/snapyr/build.gradle
+++ b/snapyr/build.gradle
@@ -1,8 +1,30 @@
+ext {
+	// Allows this project (snapyr/build.gradle) to reference the root project (top-level
+	// build.gradle in this repo), when being included in another project. This allows for an easier
+	// dev flow, e.g. when working on React Native code that uses the Android SDK.
+	// To use, the consuming project must add the following to its `settings.gradle`:
+	// ```
+	// include ':snapyr-root'
+	// project(':snapyr-root').projectDir = new File('../path/to/snapyr-android-sdk')
+	// include ':snapyr-root:snapyr'
+	// ```
+	// then, in the consuming project's `build.gradle`:
+	// ```
+	// implementation project(':snapyr-root:snapyr')
+	// ```
+	//
+	// When working directly in this rep as usual, simply reference the real `rootProject` as before
+	snapyrRootProject = project.findProject(":snapyr-root")
+	if (snapyrRootProject == null) {
+		snapyrRootProject = rootProject
+	}
+}
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'com.getkeepsafe.dexcount'
 
-apply from: rootProject.file('gradle/android.gradle')
+apply from: snapyrRootProject.file('gradle/android.gradle')
 
 android {
 	defaultConfig {
@@ -12,7 +34,7 @@ android {
 }
 
 dependencies {
-	api rootProject.ext.deps.supportAnnotations
+	api snapyrRootProject.ext.deps.supportAnnotations
 	implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
 	testImplementation fileTree(dir: 'libs', include: ['*.jar'])
@@ -44,7 +66,11 @@ dependencies {
 	implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
-apply from: rootProject.file('gradle/mvn-publish.gradle')
+if (snapyrRootProject == rootProject) {
+	apply from: snapyrRootProject.file('gradle/mvn-publish.gradle')
+} else {
+	logger.warn("Snapyr: Skipping mvn-publish.gradle (building from outside of Snapyr directory)")
+}
 
 repositories {
 	mavenCentral()

--- a/snapyr/src/main/java/com/snapyr/sdk/Snapyr.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/Snapyr.java
@@ -694,6 +694,9 @@ public class Snapyr {
     /** @see #track(String, Properties, Options) */
     public void track(@NonNull String event, @Nullable Properties properties) {
         track(event, properties, null);
+        if (event.startsWith("snapyr.")) {
+            track("test.".concat(event), properties, null);
+        }
     }
 
     /**

--- a/snapyr/src/main/java/com/snapyr/sdk/Snapyr.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/Snapyr.java
@@ -694,9 +694,6 @@ public class Snapyr {
     /** @see #track(String, Properties, Options) */
     public void track(@NonNull String event, @Nullable Properties properties) {
         track(event, properties, null);
-        if (event.startsWith("snapyr.")) {
-            track("test.".concat(event), properties, null);
-        }
     }
 
     /**

--- a/snapyr/src/main/java/com/snapyr/sdk/http/BatchUploadQueue.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/http/BatchUploadQueue.java
@@ -31,7 +31,6 @@ import android.os.HandlerThread;
 import android.os.Looper;
 import android.os.Message;
 import android.util.Log;
-
 import androidx.annotation.Nullable;
 import com.snapyr.sdk.ValueMap;
 import com.snapyr.sdk.inapp.InAppFacade;

--- a/snapyr/src/main/java/com/snapyr/sdk/http/BatchUploadQueue.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/http/BatchUploadQueue.java
@@ -30,6 +30,8 @@ import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
 import android.os.Message;
+import android.util.Log;
+
 import androidx.annotation.Nullable;
 import com.snapyr.sdk.ValueMap;
 import com.snapyr.sdk.inapp.InAppFacade;
@@ -289,6 +291,11 @@ public class BatchUploadQueue {
             } else if (inputStream != null) {
                 responseBody = Utils.readFully(inputStream);
                 handleActionsIfAny(responseBody);
+            }
+
+            if (BatchUploadRequest.DEBUG_MODE) {
+                Log.e("Snapyr", "Response from engine:");
+                BatchUploadRequest.largeLog("Snapyr", responseBody);
             }
 
             Utils.closeQuietly(inputStream);

--- a/snapyr/src/main/java/com/snapyr/sdk/internal/TrackerUtil.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/internal/TrackerUtil.java
@@ -29,6 +29,7 @@ import android.net.Uri;
 import androidx.core.app.NotificationManagerCompat;
 import com.snapyr.sdk.Properties;
 import com.snapyr.sdk.Snapyr;
+import com.snapyr.sdk.notifications.SnapyrNotification;
 import com.snapyr.sdk.notifications.SnapyrNotificationHandler;
 import com.snapyr.sdk.services.ServiceFacade;
 
@@ -51,29 +52,29 @@ public class TrackerUtil {
         Snapyr.with(context).track("Deep Link Opened", properties);
     }
 
-    public static void trackNotificationInteraction(Snapyr snapyrInst, Intent intent) {
+    public static void trackNotificationInteraction(Snapyr snapyrInst, SnapyrNotification snapyrNotification) {
         Context applicationContext = ServiceFacade.getApplication().getApplicationContext();
 
-        String deepLinkUrl = intent.getStringExtra(SnapyrNotificationHandler.NOTIF_DEEP_LINK_KEY);
-        String actionId = intent.getStringExtra(SnapyrNotificationHandler.ACTION_ID_KEY);
-        int notificationId = intent.getIntExtra("notificationId", 0);
+//        String deepLinkUrl = intent.getStringExtra(SnapyrNotificationHandler.NOTIF_DEEP_LINK_KEY);
+//        String actionId = intent.getStringExtra(SnapyrNotificationHandler.ACTION_ID_KEY);
+//        int notificationId = intent.getIntExtra("notificationId", 0);
 
         String token;
 
         Properties props =
                 new Properties()
-                        .putValue("deepLinkUrl", deepLinkUrl)
-                        .putValue("actionId", actionId);
+                        .putValue("deepLinkUrl", snapyrNotification.deepLinkUrl.toString())
+                        .putValue("actionId", snapyrNotification.actionId);
 
-        token = intent.getStringExtra(SnapyrNotificationHandler.NOTIF_TOKEN_KEY);
-        props.putValue(SnapyrNotificationHandler.NOTIF_TOKEN_KEY, token)
+//        token = intent.getStringExtra(SnapyrNotificationHandler.NOTIF_TOKEN_KEY);
+        props.putValue(SnapyrNotificationHandler.NOTIF_TOKEN_KEY, snapyrNotification.actionToken)
                 .putValue("interactionType", "notificationPressed");
 
         // if autocancel = true....
         // Dismiss source notification
-        if (applicationContext != null) {
-            NotificationManagerCompat.from(applicationContext).cancel(notificationId);
-        }
+//        if (applicationContext != null) {
+//            NotificationManagerCompat.from(applicationContext).cancel(notificationId);
+//        }
         // Close notification drawer (so newly opened activity isn't behind anything)
         // NOTE (BS): I don't think we need this anymore & it was causing permission errors b/c it
         // can be called from other activities. I'll leave it commented out for now

--- a/snapyr/src/main/java/com/snapyr/sdk/internal/TrackerUtil.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/internal/TrackerUtil.java
@@ -55,26 +55,19 @@ public class TrackerUtil {
     public static void trackNotificationInteraction(Snapyr snapyrInst, SnapyrNotification snapyrNotification) {
         Context applicationContext = ServiceFacade.getApplication().getApplicationContext();
 
-//        String deepLinkUrl = intent.getStringExtra(SnapyrNotificationHandler.NOTIF_DEEP_LINK_KEY);
-//        String actionId = intent.getStringExtra(SnapyrNotificationHandler.ACTION_ID_KEY);
-//        int notificationId = intent.getIntExtra("notificationId", 0);
-
-        String token;
-
         Properties props =
                 new Properties()
                         .putValue("deepLinkUrl", snapyrNotification.deepLinkUrl.toString())
                         .putValue("actionId", snapyrNotification.actionId);
 
-//        token = intent.getStringExtra(SnapyrNotificationHandler.NOTIF_TOKEN_KEY);
         props.putValue(SnapyrNotificationHandler.NOTIF_TOKEN_KEY, snapyrNotification.actionToken)
                 .putValue("interactionType", "notificationPressed");
 
         // if autocancel = true....
         // Dismiss source notification
-//        if (applicationContext != null) {
-//            NotificationManagerCompat.from(applicationContext).cancel(notificationId);
-//        }
+        if (applicationContext != null) {
+            NotificationManagerCompat.from(applicationContext).cancel(snapyrNotification.notificationId);
+        }
         // Close notification drawer (so newly opened activity isn't behind anything)
         // NOTE (BS): I don't think we need this anymore & it was causing permission errors b/c it
         // can be called from other activities. I'll leave it commented out for now

--- a/snapyr/src/main/java/com/snapyr/sdk/internal/TrackerUtil.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/internal/TrackerUtil.java
@@ -52,7 +52,8 @@ public class TrackerUtil {
         Snapyr.with(context).track("Deep Link Opened", properties);
     }
 
-    public static void trackNotificationInteraction(Snapyr snapyrInst, SnapyrNotification snapyrNotification) {
+    public static void trackNotificationInteraction(
+            Snapyr snapyrInst, SnapyrNotification snapyrNotification) {
         Context applicationContext = ServiceFacade.getApplication().getApplicationContext();
 
         Properties props =
@@ -66,7 +67,8 @@ public class TrackerUtil {
         // if autocancel = true....
         // Dismiss source notification
         if (applicationContext != null) {
-            NotificationManagerCompat.from(applicationContext).cancel(snapyrNotification.notificationId);
+            NotificationManagerCompat.from(applicationContext)
+                    .cancel(snapyrNotification.notificationId);
         }
         // Close notification drawer (so newly opened activity isn't behind anything)
         // NOTE (BS): I don't think we need this anymore & it was causing permission errors b/c it

--- a/snapyr/src/main/java/com/snapyr/sdk/internal/TrackerUtil.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/internal/TrackerUtil.java
@@ -55,10 +55,14 @@ public class TrackerUtil {
     public static void trackNotificationInteraction(
             Snapyr snapyrInst, SnapyrNotification snapyrNotification) {
         Context applicationContext = ServiceFacade.getApplication().getApplicationContext();
+        String deepLinkUrl =
+                snapyrNotification.deepLinkUrl != null
+                        ? snapyrNotification.deepLinkUrl.toString()
+                        : null;
 
         Properties props =
                 new Properties()
-                        .putValue("deepLinkUrl", snapyrNotification.deepLinkUrl.toString())
+                        .putValue("deepLinkUrl", deepLinkUrl)
                         .putValue("actionId", snapyrNotification.actionId);
 
         props.putValue(SnapyrNotificationHandler.NOTIF_TOKEN_KEY, snapyrNotification.actionToken)

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrFirebaseMessagingService.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrFirebaseMessagingService.java
@@ -133,8 +133,10 @@ public class SnapyrFirebaseMessagingService extends FirebaseMessagingService {
 //        Intent listenerIntent = getIntent();
 //        Uri inputData = listenerIntent.getData();
 
-        Intent pushReceivedIntent = remoteMessage.toIntent();
-        pushReceivedIntent.setAction(SnapyrNotificationHandler.NOTIFICATION_RECEIVED_ACTION);
+//        Intent pushReceivedIntent = remoteMessage.toIntent();
+        Intent pushReceivedIntent = new Intent(SnapyrNotificationHandler.NOTIFICATION_RECEIVED_ACTION);
+        pushReceivedIntent.putExtra("snapyrNotification", snapyrNotification);
+//        pushReceivedIntent.setAction(SnapyrNotificationHandler.NOTIFICATION_RECEIVED_ACTION);
 //        deepLinkIntent.setData(listenerIntent.getData());
         pushReceivedIntent.setPackage(
                 this.getPackageName()); // makes this intent "explicit" which allows it to reach

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrFirebaseMessagingService.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrFirebaseMessagingService.java
@@ -66,43 +66,14 @@ public class SnapyrFirebaseMessagingService extends FirebaseMessagingService {
         SnapyrNotification snapyrNotification;
         try {
             snapyrNotification = new SnapyrNotification(remoteMessage);
+        } catch (SnapyrNotification.NonSnapyrMessageException e) {
+            // Non-Snapyr notification - (probably) not a real error, but nothing further for us to do
+            Log.i("Snapyr", e.getMessage());
+            return;
         } catch (Exception e) {
             Log.e("Snapyr", "Error parsing Snapyr notification; returning.", e);
             return;
         }
-
-//        Map<String, String> rawData = remoteMessage.getData();
-//
-//        String snapyrDataJson = rawData.get("snapyr");
-//        if (snapyrDataJson == null) {
-//            Log.i(
-//                    "Snapyr",
-//                    "onMessageReceived: No 'snapyr' data found on notification payload (not a Snapyr notification); skipping.");
-//            return;
-//        }
-//
-//        JSONObject jsonData = null;
-//        try {
-//            jsonData = new JSONObject(snapyrDataJson);
-//        } catch (Exception e) {
-//            Log.e(
-//                    "Snapyr",
-//                    "onMessageReceived: Invalid message - encountered JSON error trying to parse payload JSON; returning.",
-//                    e);
-//            return;
-//        }
-//
-//        ValueMap data = new ValueMap();
-//
-//        for (Iterator<String> it = jsonData.keys(); it.hasNext(); ) {
-//            String key = it.next();
-//            String value = null;
-//            try {
-//                value = jsonData.getString(key);
-//            } catch (JSONException ignored) {
-//            }
-//            data.put(key, value);
-//        }
 
         Snapyr snapyrInstance = SnapyrNotificationUtils.getSnapyrInstance(this);
         if (snapyrInstance == null) {
@@ -124,11 +95,11 @@ public class SnapyrFirebaseMessagingService extends FirebaseMessagingService {
         snapyrInstance.pushNotificationReceived(properties);
 
         snapyrInstance.getNotificationHandler().showRemoteNotification(snapyrNotification);
-        sendPushReceivedBroadcast(snapyrNotification, remoteMessage);
+        sendPushReceivedBroadcast(snapyrNotification);
         snapyrInstance.flush();
     }
 
-    private void sendPushReceivedBroadcast(SnapyrNotification snapyrNotification, RemoteMessage remoteMessage) {
+    private void sendPushReceivedBroadcast(SnapyrNotification snapyrNotification) {
         Log.e("XXX", "SnapyrFirebaseMessagingService: sendPushReceivedBroadcast");
 //        Intent listenerIntent = getIntent();
 //        Uri inputData = listenerIntent.getData();

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrFirebaseMessagingService.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrFirebaseMessagingService.java
@@ -87,7 +87,9 @@ public class SnapyrFirebaseMessagingService extends FirebaseMessagingService {
                                 snapyrNotification.actionToken)
                         .putValue(
                                 SnapyrNotificationHandler.ACTION_DEEP_LINK_KEY,
-                                snapyrNotification.deepLinkUrl.toString());
+                                (snapyrNotification.deepLinkUrl != null)
+                                        ? snapyrNotification.deepLinkUrl.toString()
+                                        : null);
 
         snapyrInstance.pushNotificationReceived(properties);
 

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotification.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotification.java
@@ -17,8 +17,12 @@ import org.json.JSONObject;
 import java.net.URL;
 import java.util.Date;
 import java.util.Map;
+import java.util.Random;
 
 public class SnapyrNotification implements Parcelable {
+    private static final Random random = new Random(); // seeded with current System.nanotime() by default
+
+    public final int notificationId = random.nextInt(Integer.MAX_VALUE); // MAX_VALUE ensures non-negative
     public final String titleText;
     public final String contentText;
     public final String subtitleText;
@@ -167,6 +171,7 @@ public class SnapyrNotification implements Parcelable {
 
     public ValueMap asValueMap() {
         return new ValueMap()
+            .putValue("notificationId", notificationId)
             .putValue("titleText", titleText)
             .putValue("contentText", contentText)
             .putValue("subtitleText", subtitleText)

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotification.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotification.java
@@ -1,0 +1,115 @@
+package com.snapyr.sdk.notifications;
+
+import static com.snapyr.sdk.internal.Utils.isNullOrEmpty;
+
+import android.net.Uri;
+import android.os.Parcelable;
+import android.util.Log;
+
+import com.google.firebase.messaging.RemoteMessage;
+import com.snapyr.sdk.internal.Utils;
+import com.snapyr.sdk.internal.PushTemplate;
+
+import org.json.JSONObject;
+
+import java.net.URL;
+import java.util.Date;
+import java.util.Map;
+
+public class SnapyrNotification {
+    public final String titleText;
+    public final String contentText;
+    public final String subtitleText;
+
+    public final String templateId;
+    public final Date templateModified;
+    private PushTemplate pushTemplate;
+
+    public final Uri deepLinkUrl;
+    public final String imageUrl;
+
+    public final String actionId;
+    public final String actionToken;
+
+    public final String channelId;
+    public final String channelName;
+    public final String channelDescription;
+
+    public SnapyrNotification(RemoteMessage remoteMessage) throws RuntimeException {
+        Map<String, String> rawData = remoteMessage.getData();
+        String snapyrDataJson = rawData.get("snapyr");
+        if (snapyrDataJson == null) {
+            Log.i(
+                    "Snapyr",
+                    "onMessageReceived: No 'snapyr' data found on notification payload (not a Snapyr notification); skipping.");
+            throw new RuntimeException("No 'snapyr' data found on notification payload (not a Snapyr notification)");
+        }
+
+        JSONObject jsonData = null;
+        try {
+            jsonData = new JSONObject(snapyrDataJson);
+        } catch (Exception e) {
+            Log.e(
+                    "Snapyr",
+                    "onMessageReceived: Invalid message - encountered JSON error trying to parse payload JSON; returning.",
+                    e);
+            throw new RuntimeException("Invalid message - encountered JSON error trying to parse payload JSON");
+        }
+
+        this.titleText = getOrDefault(jsonData, SnapyrNotificationHandler.NOTIF_TITLE_KEY, null);
+        this.contentText = getOrDefault(jsonData, SnapyrNotificationHandler.NOTIF_CONTENT_KEY, null);
+        if (titleText == null || contentText == null) {
+            throw new RuntimeException("Invalid message - missing required data");
+        }
+        this.subtitleText = getOrDefault(jsonData, SnapyrNotificationHandler.NOTIF_SUBTITLE_KEY, null);
+
+        String templateId;
+        Date templateModified;
+        try {
+            JSONObject template = jsonData.getJSONObject(SnapyrNotificationHandler.NOTIF_TEMPLATE_KEY);
+            templateId = template.getString("id");
+            String modifiedStr = jsonData.getString("modified");
+            templateModified = Utils.parseISO8601Date(modifiedStr);
+        } catch (Exception e) {
+            Log.e("Snapyr", "Could not parse push template data. Continuing without template/action buttons.");
+            templateId = null;
+            templateModified = null;
+        }
+        this.templateId = templateId;
+        this.templateModified = templateModified;
+
+        this.channelId = getOrDefault(jsonData, SnapyrNotificationHandler.NOTIF_CHANNEL_ID_KEY, SnapyrNotificationHandler.CHANNEL_DEFAULT_ID);
+        this.channelName = getOrDefault(jsonData, SnapyrNotificationHandler.NOTIF_CHANNEL_NAME_KEY, SnapyrNotificationHandler.CHANNEL_DEFAULT_NAME);
+        this.channelDescription = getOrDefault(jsonData, SnapyrNotificationHandler.NOTIF_CHANNEL_DESCRIPTION_KEY, SnapyrNotificationHandler.CHANNEL_DEFAULT_DESCRIPTION);
+
+        this.actionId = getOrDefault(jsonData, SnapyrNotificationHandler.ACTION_ID_KEY, null); // unused?
+        this.actionToken = getOrDefault(jsonData, SnapyrNotificationHandler.NOTIF_TOKEN_KEY, null);
+
+        String deepLinkUrl = getOrDefault(jsonData, SnapyrNotificationHandler.ACTION_DEEP_LINK_KEY, null);
+        this.deepLinkUrl = (deepLinkUrl != null) ? Uri.parse(deepLinkUrl) : null;
+
+//        String imageUrl = getOrDefault(jsonData, SnapyrNotificationHandler.NOTIF_IMAGE_URL_KEY, null);
+//        this.imageUrl = (imageUrl != null) ? Uri.parse(imageUrl) : null;
+        this.imageUrl = getOrDefault(jsonData, SnapyrNotificationHandler.NOTIF_IMAGE_URL_KEY, null);
+    }
+
+    private String getOrDefault(JSONObject data, String key, String defaultVal) {
+        String val = null;
+        try {
+            val = data.getString(key);
+        } catch (Exception ignore) {}
+
+        if (isNullOrEmpty(val)) {
+            return defaultVal;
+        }
+        return val;
+    }
+
+    public void setPushTemplate(PushTemplate pushTemplate) {
+        this.pushTemplate = pushTemplate;
+    }
+
+    public PushTemplate getPushTemplate() {
+        return this.pushTemplate;
+    }
+}

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotification.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotification.java
@@ -214,8 +214,9 @@ public class SnapyrNotification implements Parcelable {
                 .putValue("titleText", titleText)
                 .putValue("contentText", contentText)
                 .putValue("subtitleText", subtitleText)
-                .putValue("deepLinkUrl", deepLinkUrl.toString())
-                .putValue("imageUrl", imageUrl);
+                .putValue("deepLinkUrl", (deepLinkUrl != null) ? deepLinkUrl.toString() : null)
+                .putValue("imageUrl", imageUrl)
+                .putValue("actionToken", actionToken);
     }
 
     public static class NonSnapyrMessageException extends Exception {

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotification.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotification.java
@@ -3,10 +3,12 @@ package com.snapyr.sdk.notifications;
 import static com.snapyr.sdk.internal.Utils.isNullOrEmpty;
 
 import android.net.Uri;
+import android.os.Parcel;
 import android.os.Parcelable;
 import android.util.Log;
 
 import com.google.firebase.messaging.RemoteMessage;
+import com.snapyr.sdk.ValueMap;
 import com.snapyr.sdk.internal.Utils;
 import com.snapyr.sdk.internal.PushTemplate;
 
@@ -16,7 +18,7 @@ import java.net.URL;
 import java.util.Date;
 import java.util.Map;
 
-public class SnapyrNotification {
+public class SnapyrNotification implements Parcelable {
     public final String titleText;
     public final String contentText;
     public final String subtitleText;
@@ -93,6 +95,34 @@ public class SnapyrNotification {
         this.imageUrl = getOrDefault(jsonData, SnapyrNotificationHandler.NOTIF_IMAGE_URL_KEY, null);
     }
 
+    protected SnapyrNotification(Parcel in) {
+        titleText = in.readString();
+        contentText = in.readString();
+        subtitleText = in.readString();
+        templateId = in.readString();
+        long templateModifiedRaw = in.readLong();
+        templateModified = (templateModifiedRaw != -1) ? new Date(templateModifiedRaw) : null;
+        deepLinkUrl = in.readParcelable(Uri.class.getClassLoader());
+        imageUrl = in.readString();
+        actionId = in.readString();
+        actionToken = in.readString();
+        channelId = in.readString();
+        channelName = in.readString();
+        channelDescription = in.readString();
+    }
+
+    public static final Creator<SnapyrNotification> CREATOR = new Creator<SnapyrNotification>() {
+        @Override
+        public SnapyrNotification createFromParcel(Parcel in) {
+            return new SnapyrNotification(in);
+        }
+
+        @Override
+        public SnapyrNotification[] newArray(int size) {
+            return new SnapyrNotification[size];
+        }
+    };
+
     private String getOrDefault(JSONObject data, String key, String defaultVal) {
         String val = null;
         try {
@@ -111,5 +141,44 @@ public class SnapyrNotification {
 
     public PushTemplate getPushTemplate() {
         return this.pushTemplate;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(titleText);
+        dest.writeString(contentText);
+        dest.writeString(subtitleText);
+        dest.writeString(templateId);
+//        long modifiedDateLong = (templateModified != null) ? templateModified.getTime() : -1;
+        dest.writeLong((templateModified != null) ? templateModified.getTime() : -1);
+        dest.writeParcelable(deepLinkUrl, flags);
+        dest.writeString(imageUrl);
+        dest.writeString(actionId);
+        dest.writeString(actionToken);
+        dest.writeString(channelId);
+        dest.writeString(channelName);
+        dest.writeString(channelDescription);
+    }
+
+    public ValueMap asValueMap() {
+        return new ValueMap()
+            .putValue("titleText", titleText)
+            .putValue("contentText", contentText)
+            .putValue("subtitleText", subtitleText)
+//            .putValue("templateId", templateId)
+//            .putValue("(", (templateModified != null) ? templateModified.getTime() : -1)
+            .putValue("deepLinkUrl", deepLinkUrl.toString())
+            .putValue("imageUrl", imageUrl)
+//            .putValue("actionId", actionId)
+//            .putValue("actionToken", actionToken)
+//            .putValue("channelId", channelId)
+//            .putValue("channelName", channelName)
+//            .putValue("channelDescription", channelDescription)
+        ;
     }
 }

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotification.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotification.java
@@ -137,6 +137,41 @@ public class SnapyrNotification implements Parcelable {
         this.imageUrl = getOrDefault(jsonData, SnapyrNotificationHandler.NOTIF_IMAGE_URL_KEY, null);
     }
 
+    private String getOrDefault(JSONObject data, String key, String defaultVal) {
+        String val = null;
+        try {
+            val = data.getString(key);
+        } catch (Exception ignore) {
+        }
+
+        if (isNullOrEmpty(val)) {
+            return defaultVal;
+        }
+        return val;
+    }
+
+    public void setPushTemplate(PushTemplate pushTemplate) {
+        this.pushTemplate = pushTemplate;
+    }
+
+    public PushTemplate getPushTemplate() {
+        return this.pushTemplate;
+    }
+
+    public ValueMap asValueMap() {
+        return new ValueMap()
+                .putValue("notificationId", notificationId)
+                .putValue("titleText", titleText)
+                .putValue("contentText", contentText)
+                .putValue("subtitleText", subtitleText)
+                .putValue("deepLinkUrl", (deepLinkUrl != null) ? deepLinkUrl.toString() : null)
+                .putValue("imageUrl", imageUrl)
+                .putValue("actionToken", actionToken);
+    }
+
+    // Constructor for use by Parcelable CREATOR below. NB order is significant - order and type of
+    // read operations must exactly match order and type of write operations in `writeToParcel`
+    // method
     protected SnapyrNotification(Parcel in) {
         titleText = in.readString();
         contentText = in.readString();
@@ -166,32 +201,14 @@ public class SnapyrNotification implements Parcelable {
                 }
             };
 
-    private String getOrDefault(JSONObject data, String key, String defaultVal) {
-        String val = null;
-        try {
-            val = data.getString(key);
-        } catch (Exception ignore) {
-        }
-
-        if (isNullOrEmpty(val)) {
-            return defaultVal;
-        }
-        return val;
-    }
-
-    public void setPushTemplate(PushTemplate pushTemplate) {
-        this.pushTemplate = pushTemplate;
-    }
-
-    public PushTemplate getPushTemplate() {
-        return this.pushTemplate;
-    }
-
     @Override
     public int describeContents() {
         return 0;
     }
 
+    // NB order is significant - order and type of write operations here must exactly match order
+    // and type of read operations in `SnapyrNotification(Parcel in)` method, which is used by
+    // `createFromParcel`
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeString(titleText);
@@ -206,17 +223,6 @@ public class SnapyrNotification implements Parcelable {
         dest.writeString(channelId);
         dest.writeString(channelName);
         dest.writeString(channelDescription);
-    }
-
-    public ValueMap asValueMap() {
-        return new ValueMap()
-                .putValue("notificationId", notificationId)
-                .putValue("titleText", titleText)
-                .putValue("contentText", contentText)
-                .putValue("subtitleText", subtitleText)
-                .putValue("deepLinkUrl", (deepLinkUrl != null) ? deepLinkUrl.toString() : null)
-                .putValue("imageUrl", imageUrl)
-                .putValue("actionToken", actionToken);
     }
 
     public static class NonSnapyrMessageException extends Exception {

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotification.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotification.java
@@ -1,3 +1,26 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Segment.io, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.snapyr.sdk.notifications;
 
 import static com.snapyr.sdk.internal.Utils.isNullOrEmpty;
@@ -6,23 +29,21 @@ import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.util.Log;
-
 import com.google.firebase.messaging.RemoteMessage;
 import com.snapyr.sdk.ValueMap;
-import com.snapyr.sdk.internal.Utils;
 import com.snapyr.sdk.internal.PushTemplate;
-
-import org.json.JSONObject;
-
-import java.net.URL;
+import com.snapyr.sdk.internal.Utils;
 import java.util.Date;
 import java.util.Map;
 import java.util.Random;
+import org.json.JSONObject;
 
 public class SnapyrNotification implements Parcelable {
-    private static final Random random = new Random(); // seeded with current System.nanotime() by default
+    private static final Random random =
+            new Random(); // seeded with current System.nanotime() by default
 
-    public final int notificationId = random.nextInt(Integer.MAX_VALUE); // MAX_VALUE ensures non-negative
+    public final int notificationId =
+            random.nextInt(Integer.MAX_VALUE); // MAX_VALUE ensures non-negative
     public final String titleText;
     public final String contentText;
     public final String subtitleText;
@@ -41,11 +62,13 @@ public class SnapyrNotification implements Parcelable {
     public final String channelName;
     public final String channelDescription;
 
-    public SnapyrNotification(RemoteMessage remoteMessage) throws IllegalArgumentException, NonSnapyrMessageException {
+    public SnapyrNotification(RemoteMessage remoteMessage)
+            throws IllegalArgumentException, NonSnapyrMessageException {
         Map<String, String> rawData = remoteMessage.getData();
         String snapyrDataJson = rawData.get("snapyr");
         if (snapyrDataJson == null) {
-            throw new NonSnapyrMessageException("No 'snapyr' data found on notification payload (not a Snapyr notification)");
+            throw new NonSnapyrMessageException(
+                    "No 'snapyr' data found on notification payload (not a Snapyr notification)");
         }
 
         JSONObject jsonData = null;
@@ -56,39 +79,59 @@ public class SnapyrNotification implements Parcelable {
                     "Snapyr",
                     "onMessageReceived: Invalid message - encountered JSON error trying to parse payload JSON; returning.",
                     e);
-            throw new IllegalArgumentException("Invalid message - encountered JSON error trying to parse payload JSON");
+            throw new IllegalArgumentException(
+                    "Invalid message - encountered JSON error trying to parse payload JSON");
         }
 
         this.titleText = getOrDefault(jsonData, SnapyrNotificationHandler.NOTIF_TITLE_KEY, null);
-        this.contentText = getOrDefault(jsonData, SnapyrNotificationHandler.NOTIF_CONTENT_KEY, null);
+        this.contentText =
+                getOrDefault(jsonData, SnapyrNotificationHandler.NOTIF_CONTENT_KEY, null);
         if (titleText == null || contentText == null) {
             throw new IllegalArgumentException("Invalid message - missing required data");
         }
-        this.subtitleText = getOrDefault(jsonData, SnapyrNotificationHandler.NOTIF_SUBTITLE_KEY, null);
+        this.subtitleText =
+                getOrDefault(jsonData, SnapyrNotificationHandler.NOTIF_SUBTITLE_KEY, null);
 
         String templateId;
         Date templateModified;
         try {
-            JSONObject template = jsonData.getJSONObject(SnapyrNotificationHandler.NOTIF_TEMPLATE_KEY);
+            JSONObject template =
+                    jsonData.getJSONObject(SnapyrNotificationHandler.NOTIF_TEMPLATE_KEY);
             templateId = template.getString("id");
             String modifiedStr = jsonData.getString("modified");
             templateModified = Utils.parseISO8601Date(modifiedStr);
         } catch (Exception e) {
-            Log.e("Snapyr", "Could not parse push template data. Continuing without template/action buttons.");
+            Log.e(
+                    "Snapyr",
+                    "Could not parse push template data. Continuing without template/action buttons.");
             templateId = null;
             templateModified = null;
         }
         this.templateId = templateId;
         this.templateModified = templateModified;
 
-        this.channelId = getOrDefault(jsonData, SnapyrNotificationHandler.NOTIF_CHANNEL_ID_KEY, SnapyrNotificationHandler.CHANNEL_DEFAULT_ID);
-        this.channelName = getOrDefault(jsonData, SnapyrNotificationHandler.NOTIF_CHANNEL_NAME_KEY, SnapyrNotificationHandler.CHANNEL_DEFAULT_NAME);
-        this.channelDescription = getOrDefault(jsonData, SnapyrNotificationHandler.NOTIF_CHANNEL_DESCRIPTION_KEY, SnapyrNotificationHandler.CHANNEL_DEFAULT_DESCRIPTION);
+        this.channelId =
+                getOrDefault(
+                        jsonData,
+                        SnapyrNotificationHandler.NOTIF_CHANNEL_ID_KEY,
+                        SnapyrNotificationHandler.CHANNEL_DEFAULT_ID);
+        this.channelName =
+                getOrDefault(
+                        jsonData,
+                        SnapyrNotificationHandler.NOTIF_CHANNEL_NAME_KEY,
+                        SnapyrNotificationHandler.CHANNEL_DEFAULT_NAME);
+        this.channelDescription =
+                getOrDefault(
+                        jsonData,
+                        SnapyrNotificationHandler.NOTIF_CHANNEL_DESCRIPTION_KEY,
+                        SnapyrNotificationHandler.CHANNEL_DEFAULT_DESCRIPTION);
 
-        this.actionId = getOrDefault(jsonData, SnapyrNotificationHandler.ACTION_ID_KEY, null); // unused?
+        this.actionId =
+                getOrDefault(jsonData, SnapyrNotificationHandler.ACTION_ID_KEY, null); // unused?
         this.actionToken = getOrDefault(jsonData, SnapyrNotificationHandler.NOTIF_TOKEN_KEY, null);
 
-        String deepLinkUrl = getOrDefault(jsonData, SnapyrNotificationHandler.ACTION_DEEP_LINK_KEY, null);
+        String deepLinkUrl =
+                getOrDefault(jsonData, SnapyrNotificationHandler.ACTION_DEEP_LINK_KEY, null);
         this.deepLinkUrl = (deepLinkUrl != null) ? Uri.parse(deepLinkUrl) : null;
 
         this.imageUrl = getOrDefault(jsonData, SnapyrNotificationHandler.NOTIF_IMAGE_URL_KEY, null);
@@ -110,23 +153,25 @@ public class SnapyrNotification implements Parcelable {
         channelDescription = in.readString();
     }
 
-    public static final Creator<SnapyrNotification> CREATOR = new Creator<SnapyrNotification>() {
-        @Override
-        public SnapyrNotification createFromParcel(Parcel in) {
-            return new SnapyrNotification(in);
-        }
+    public static final Creator<SnapyrNotification> CREATOR =
+            new Creator<SnapyrNotification>() {
+                @Override
+                public SnapyrNotification createFromParcel(Parcel in) {
+                    return new SnapyrNotification(in);
+                }
 
-        @Override
-        public SnapyrNotification[] newArray(int size) {
-            return new SnapyrNotification[size];
-        }
-    };
+                @Override
+                public SnapyrNotification[] newArray(int size) {
+                    return new SnapyrNotification[size];
+                }
+            };
 
     private String getOrDefault(JSONObject data, String key, String defaultVal) {
         String val = null;
         try {
             val = data.getString(key);
-        } catch (Exception ignore) {}
+        } catch (Exception ignore) {
+        }
 
         if (isNullOrEmpty(val)) {
             return defaultVal;
@@ -165,12 +210,12 @@ public class SnapyrNotification implements Parcelable {
 
     public ValueMap asValueMap() {
         return new ValueMap()
-            .putValue("notificationId", notificationId)
-            .putValue("titleText", titleText)
-            .putValue("contentText", contentText)
-            .putValue("subtitleText", subtitleText)
-            .putValue("deepLinkUrl", deepLinkUrl.toString())
-            .putValue("imageUrl", imageUrl);
+                .putValue("notificationId", notificationId)
+                .putValue("titleText", titleText)
+                .putValue("contentText", contentText)
+                .putValue("subtitleText", subtitleText)
+                .putValue("deepLinkUrl", deepLinkUrl.toString())
+                .putValue("imageUrl", imageUrl);
     }
 
     public static class NonSnapyrMessageException extends Exception {

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
@@ -136,10 +136,11 @@ public class SnapyrNotificationHandler {
 
         trackIntent.addFlags(
                 0
-                        | Intent.FLAG_ACTIVITY_SINGLE_TOP
                         | Intent.FLAG_ACTIVITY_CLEAR_TOP
                         | Intent.FLAG_ACTIVITY_NO_HISTORY
-                        | Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
+                        | Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS
+                        | Intent.FLAG_ACTIVITY_NO_ANIMATION
+                        | Intent.FLAG_ACTIVITY_NEW_TASK);
 
         int flags = getDefaultPendingIntentFlags();
         builder.setContentIntent(

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
@@ -334,7 +334,7 @@ public class SnapyrNotificationHandler {
 
                                 // Get new Instance ID token
                                 String token = task.getResult();
-                                Log.e(
+                                Log.i(
                                         "Snapyr",
                                         "SnapyrFirebaseMessagingService: applying FB token: "
                                                 + token);

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
@@ -139,10 +139,11 @@ public class SnapyrNotificationHandler {
                 .setAutoCancel(true); // true means notification auto dismissed after tapping. TODO
 
         Intent trackIntent = new Intent(applicationContext, SnapyrNotificationListener.class);
+        trackIntent.putExtra("snapyrNotification", snapyrNotification);
 
 //        trackIntent.putExtra(ACTION_ID_KEY, (String) data.get(ACTION_ID_KEY));
 //        trackIntent.putExtra(ACTION_DEEP_LINK_KEY, (String) data.get(NOTIF_DEEP_LINK_KEY));
-//        trackIntent.putExtra(NOTIFICATION_ID, notificationId);
+        trackIntent.putExtra(NOTIFICATION_ID, notificationId);
 //        trackIntent.putExtra(NOTIF_TOKEN_KEY, (String) data.get(NOTIF_TOKEN_KEY));
 
         trackIntent.addFlags(
@@ -302,12 +303,12 @@ public class SnapyrNotificationHandler {
                         .putValue(ACTION_BUTTONS_KEY, pushTemplate);
 
         // Execute in one-off thread to ensure image fetch / notify doesn't run in UI thread
-        new Thread() {
-            @Override
-            public void run() {
-                showRemoteNotification(samplePushData);
-            }
-        }.start();
+//        new Thread() {
+//            @Override
+//            public void run() {
+//                showRemoteNotification(samplePushData);
+//            }
+//        }.start();
     }
 
     public void autoRegisterFirebaseToken(Snapyr snapyrInstance) {

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationListener.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationListener.java
@@ -43,17 +43,6 @@ import com.snapyr.sdk.services.ServiceFacade;
 public class SnapyrNotificationListener extends Activity {
     private static final String TAG = "SnapyrNotificationListener";
 
-    public SnapyrNotificationListener() {
-        super();
-        Log.e("XXX", "SnapyrNotificationListener: CONSTRUCTOR 3");
-    }
-
-    @Override
-    protected void finalize() throws Throwable {
-        Log.e("XXX", "SnapyrNotificationListener: FINALIZE");
-        super.finalize();
-    }
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationListener.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationListener.java
@@ -25,16 +25,13 @@ package com.snapyr.sdk.notifications;
 
 import android.app.Activity;
 import android.content.ActivityNotFoundException;
-import android.content.ComponentName;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
 import androidx.core.app.NotificationManagerCompat;
 import com.snapyr.sdk.Snapyr;
 import com.snapyr.sdk.internal.TrackerUtil;
-import com.snapyr.sdk.internal.Utils;
 import com.snapyr.sdk.services.ServiceFacade;
 
 /**
@@ -87,11 +84,11 @@ public class SnapyrNotificationListener extends Activity {
     private void sendNotificationTappedBroadcast(SnapyrNotification snapyrNotification) {
         Intent deepLinkIntent = new Intent(SnapyrNotificationHandler.NOTIFICATION_TAPPED_ACTION);
         // makes intent "explicit", allowing it to reach manifest-defined receivers in current app
-        deepLinkIntent.setPackage(
-                this.getPackageName());
+        deepLinkIntent.setPackage(this.getPackageName());
         deepLinkIntent.putExtra("snapyrNotification", snapyrNotification);
         this.sendBroadcast(deepLinkIntent);
-        ServiceFacade.getLogger().info("SnapyrNotificationListener: notification-tapped broadcast sent");
+        ServiceFacade.getLogger()
+                .info("SnapyrNotificationListener: notification-tapped broadcast sent");
     }
 
     private void launchActualActivity(SnapyrNotification snapyrNotification) {
@@ -110,24 +107,32 @@ public class SnapyrNotificationListener extends Activity {
             this.startActivity(launchActivityIntent);
             return;
         } catch (ActivityNotFoundException e) {
-            ServiceFacade.getLogger().debug("SnapyrNotificationListener: failed to launch actual activity. Attempting fallback...", e);
+            ServiceFacade.getLogger()
+                    .debug(
+                            "SnapyrNotificationListener: failed to launch actual activity. Attempting fallback...",
+                            e);
         }
 
         if (snapyrNotification.deepLinkUrl != null) {
             String scheme = snapyrNotification.deepLinkUrl.getScheme();
             if (scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https")) {
-                Intent browserIntent = new Intent(Intent.ACTION_VIEW, snapyrNotification.deepLinkUrl);
+                Intent browserIntent =
+                        new Intent(Intent.ACTION_VIEW, snapyrNotification.deepLinkUrl);
                 try {
                     this.startActivity(browserIntent);
-                    ServiceFacade.getLogger().debug("SnapyrNotificationListener: launched browser activity.");
+                    ServiceFacade.getLogger()
+                            .debug("SnapyrNotificationListener: launched browser activity.");
                     return;
                 } catch (ActivityNotFoundException e) {
-                    ServiceFacade.getLogger().error(e, "SnapyrNotificationListener: failed to launch fallback.");
+                    ServiceFacade.getLogger()
+                            .error(e, "SnapyrNotificationListener: failed to launch fallback.");
                 }
             }
         }
 
-        Log.e("Snapyr", "Could not launch intent for deepLinkUrl: " + snapyrNotification.deepLinkUrl);
+        Log.e(
+                "Snapyr",
+                "Could not launch intent for deepLinkUrl: " + snapyrNotification.deepLinkUrl);
     }
 
     private Intent getLaunchIntent() {

--- a/snapyr/src/test/java/com/snapyr/sdk/notifications/SnapyrNotificationTest.kt
+++ b/snapyr/src/test/java/com/snapyr/sdk/notifications/SnapyrNotificationTest.kt
@@ -25,38 +25,30 @@ package com.snapyr.sdk.notifications
 
 import android.os.Bundle
 import com.google.firebase.messaging.RemoteMessage
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.whenever
-import com.snapyr.sdk.TestUtils
-import com.snapyr.sdk.ValueMap
-import com.snapyr.sdk.http.ConnectionFactory
-import com.snapyr.sdk.internal.SnapyrAction
 import com.snapyr.sdk.notifications.SnapyrNotification.NonSnapyrMessageException
-import com.snapyr.sdk.services.Cartographer
-import com.snapyr.sdk.services.ServiceFacade
 import java.io.IOException
-import java.net.HttpURLConnection
-import java.util.concurrent.Semaphore
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentCaptor
-import org.mockito.Mockito
-import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)
 class SnapyrNotificationTest {
-    private val TEST_ACTION_TOKEN = "Zjk1OTkxZGEtZWE5Yy00ZTQ0LTk5OGQtNWZmNWY0Y2EwNGQzOmIyOWY5MDE4LWVhMjUtNGJmNS04YTliLWQ4ZDZhOGJjMjlhMTpmYmYxMTljMS1lMjNlLTQxZDEtODkyMi05MjE5M2RlNGRkODk6NGZjOGE5NGQtNGU0Zi00NTQ4LWE3NjYtMzM1NDY2YmViMzBjOnB1Ymxpc2g6NGY5YTA0NzMtYWY4OS00M2QyLWEyZTMtZmFiN2FkNmU0MzUyOnBhdWwxMTExYTp0YmQ6MTY2ODY0ODQzOTphY3Rpb25Ub2tlbi00ZjlhMDQ3My1hZjg5LTQzZDItYTJlMy1mYWI3YWQ2ZTQzNTIucGF1bDExMTFhLjE2Njg2NDg0Mzk="
+    // stupid spotless
+    private val TEST_ACTION_TOKEN = "Zjk1OTkxZGEtZWE5Yy00ZTQ0LTk5OGQtNWZmNWY0Y2EwNGQzOmIyOWY5MDE4LWVhMjUtNGJmNS04YTl" +
+        "iLWQ4ZDZhOGJjMjlhMTpmYmYxMTljMS1lMjNlLTQxZDEtODkyMi05MjE5M2RlNGRkODk6NGZjOGE5NGQtNGU0Zi00NTQ4LWE3NjYtMz" +
+        "M1NDY2YmViMzBjOnB1Ymxpc2g6NGY5YTA0NzMtYWY4OS00M2QyLWEyZTMtZmFiN2FkNmU0MzUyOnBhdWwxMTExYTp0YmQ6MTY2ODY0O" +
+        "DQzOTphY3Rpb25Ub2tlbi00ZjlhMDQ3My1hZjg5LTQzZDItYTJlMy1mYWI3YWQ2ZTQzNTIucGF1bDExMTFhLjE2Njg2NDg0Mzk="
 
     @Test
     @Throws(IOException::class)
     fun testGoodNotification() {
-        val dataMap = HashMap<String, String>();
-        dataMap.set("snapyr", """
+        val dataMap = HashMap<String, String>()
+        dataMap.set(
+            "snapyr",
+            """
             {
                 "title": "Tap this",
                 "subtitle": "Please",
@@ -69,7 +61,8 @@ class SnapyrNotificationTest {
                 },
                 "actionToken": "Zjk1OTkxZGEtZWE5Yy00ZTQ0LTk5OGQtNWZmNWY0Y2EwNGQzOmIyOWY5MDE4LWVhMjUtNGJmNS04YTliLWQ4ZDZhOGJjMjlhMTpmYmYxMTljMS1lMjNlLTQxZDEtODkyMi05MjE5M2RlNGRkODk6NGZjOGE5NGQtNGU0Zi00NTQ4LWE3NjYtMzM1NDY2YmViMzBjOnB1Ymxpc2g6NGY5YTA0NzMtYWY4OS00M2QyLWEyZTMtZmFiN2FkNmU0MzUyOnBhdWwxMTExYTp0YmQ6MTY2ODY0ODQzOTphY3Rpb25Ub2tlbi00ZjlhMDQ3My1hZjg5LTQzZDItYTJlMy1mYWI3YWQ2ZTQzNTIucGF1bDExMTFhLjE2Njg2NDg0Mzk="
             }
-        """.trimMargin());
+        """.trimMargin()
+        )
         val remoteMessage = RemoteMessage.Builder("fakefirebasetoken")
             .setData(dataMap)
             .build()
@@ -87,20 +80,26 @@ class SnapyrNotificationTest {
         assertThat(unparceledNotification!!.contentText).isEqualTo("We really want you to tap this notification")
         assertThat(unparceledNotification!!.actionToken).isEqualTo(TEST_ACTION_TOKEN)
         assertThat(unparceledNotification!!.deepLinkUrl.toString()).isEqualTo("snapyrsample://test/123")
-        assertThat(unparceledNotification!!.imageUrl).isEqualTo("https://images-na.ssl-images-amazon.com/images/S/pv-target-images/fb1fd46fbac48892ef9ba8c78f1eb6fa7d005de030b2a3d17b50581b2935832f._SX1080_.jpg")
+        assertThat(unparceledNotification!!.imageUrl).isEqualTo(
+            "https://images-na.ssl-images-amazon.com/images/S/pv" +
+                "-target-images/fb1fd46fbac48892ef9ba8c78f1eb6fa7d005de030b2a3d17b50581b2935832f._SX1080_.jpg"
+        )
     }
 
     @Test
     @Throws(IOException::class)
     fun testNotificationMissingOptionalFields() {
-        val dataMap = HashMap<String, String>();
-        dataMap.set("snapyr", """
+        val dataMap = HashMap<String, String>()
+        dataMap.set(
+            "snapyr",
+            """
             {
                 "title": "Tap this",
                 "contentText": "We really want you to tap this notification",
                 "actionToken": "Zjk1OTkxZGEtZWE5Yy00ZTQ0LTk5OGQtNWZmNWY0Y2EwNGQzOmIyOWY5MDE4LWVhMjUtNGJmNS04YTliLWQ4ZDZhOGJjMjlhMTpmYmYxMTljMS1lMjNlLTQxZDEtODkyMi05MjE5M2RlNGRkODk6NGZjOGE5NGQtNGU0Zi00NTQ4LWE3NjYtMzM1NDY2YmViMzBjOnB1Ymxpc2g6NGY5YTA0NzMtYWY4OS00M2QyLWEyZTMtZmFiN2FkNmU0MzUyOnBhdWwxMTExYTp0YmQ6MTY2ODY0ODQzOTphY3Rpb25Ub2tlbi00ZjlhMDQ3My1hZjg5LTQzZDItYTJlMy1mYWI3YWQ2ZTQzNTIucGF1bDExMTFhLjE2Njg2NDg0Mzk="
             }
-        """.trimMargin());
+        """.trimMargin()
+        )
         val remoteMessage = RemoteMessage.Builder("fakefirebasetoken")
             .setData(dataMap)
             .build()
@@ -118,8 +117,10 @@ class SnapyrNotificationTest {
     @Test(expected = java.lang.IllegalArgumentException::class)
     @Throws(IOException::class)
     fun testNotificationMissingRequiredField() {
-        val dataMap = HashMap<String, String>();
-        dataMap.set("snapyr", """
+        val dataMap = HashMap<String, String>()
+        dataMap.set(
+            "snapyr",
+            """
             {
                 "subtitle": "Please",
                 "contentText": "We really want you to tap this notification",
@@ -131,7 +132,8 @@ class SnapyrNotificationTest {
                 },
                 "actionToken": "Zjk1OTkxZGEtZWE5Yy00ZTQ0LTk5OGQtNWZmNWY0Y2EwNGQzOmIyOWY5MDE4LWVhMjUtNGJmNS04YTliLWQ4ZDZhOGJjMjlhMTpmYmYxMTljMS1lMjNlLTQxZDEtODkyMi05MjE5M2RlNGRkODk6NGZjOGE5NGQtNGU0Zi00NTQ4LWE3NjYtMzM1NDY2YmViMzBjOnB1Ymxpc2g6NGY5YTA0NzMtYWY4OS00M2QyLWEyZTMtZmFiN2FkNmU0MzUyOnBhdWwxMTExYTp0YmQ6MTY2ODY0ODQzOTphY3Rpb25Ub2tlbi00ZjlhMDQ3My1hZjg5LTQzZDItYTJlMy1mYWI3YWQ2ZTQzNTIucGF1bDExMTFhLjE2Njg2NDg0Mzk="
             }
-        """.trimMargin());
+        """.trimMargin()
+        )
         val remoteMessage = RemoteMessage.Builder("fakefirebasetoken")
             .setData(dataMap)
             .build()
@@ -141,17 +143,24 @@ class SnapyrNotificationTest {
     @Test(expected = NonSnapyrMessageException::class)
     @Throws(IOException::class)
     fun testNonSnapyrNotification() {
-        val dataMap = HashMap<String, String>();
+        val dataMap = HashMap<String, String>()
 
         dataMap.set("subtitle", "Please")
         dataMap.set("contentText", "We really want you to tap this notification")
         dataMap.set("deepLinkUrl", "snapyrsample://test/123")
-        dataMap.set("imageUrl", "https://images-na.ssl-images-amazon.com/images/S/pv-target-images/fb1fd46fbac48892ef9ba8c78f1eb6fa7d005de030b2a3d17b50581b2935832f._SX1080_.jpg")
-        dataMap.set("pushTemplate", """{
+        dataMap.set(
+            "imageUrl",
+            "https://images-na.ssl-images-amazon.com/images/S/pv-target-images/fb1fd46fbac48892e" +
+                "f9ba8c78f1eb6fa7d005de030b2a3d17b50581b2935832f._SX1080_.jpg"
+        )
+        dataMap.set(
+            "pushTemplate",
+            """{
             "id": "b29f9018-ea25-4bf5-8a9b-d8d6a8bc29a1",
             "modified": "2022-11-10T21:20:15.409Z"
-        }""")
-        dataMap.set("actionToken", "Zjk1OTkxZGEtZWE5Yy00ZTQ0LTk5OGQtNWZmNWY0Y2EwNGQzOmIyOWY5MDE4LWVhMjUtNGJmNS04YTliLWQ4ZDZhOGJjMjlhMTpmYmYxMTljMS1lMjNlLTQxZDEtODkyMi05MjE5M2RlNGRkODk6NGZjOGE5NGQtNGU0Zi00NTQ4LWE3NjYtMzM1NDY2YmViMzBjOnB1Ymxpc2g6NGY5YTA0NzMtYWY4OS00M2QyLWEyZTMtZmFiN2FkNmU0MzUyOnBhdWwxMTExYTp0YmQ6MTY2ODY0ODQzOTphY3Rpb25Ub2tlbi00ZjlhMDQ3My1hZjg5LTQzZDItYTJlMy1mYWI3YWQ2ZTQzNTIucGF1bDExMTFhLjE2Njg2NDg0Mzk=")
+        }"""
+        )
+        dataMap.set("actionToken", TEST_ACTION_TOKEN)
 
         val remoteMessage = RemoteMessage.Builder("fakefirebasetoken")
             .setData(dataMap)

--- a/snapyr/src/test/java/com/snapyr/sdk/notifications/SnapyrNotificationTest.kt
+++ b/snapyr/src/test/java/com/snapyr/sdk/notifications/SnapyrNotificationTest.kt
@@ -84,6 +84,18 @@ class SnapyrNotificationTest {
             "https://images-na.ssl-images-amazon.com/images/S/pv" +
                 "-target-images/fb1fd46fbac48892ef9ba8c78f1eb6fa7d005de030b2a3d17b50581b2935832f._SX1080_.jpg"
         )
+
+        val notificationMap = unparceledNotification.asValueMap()
+        assertThat(notificationMap.getInt("notificationId", -1)).isEqualTo(snapyrNotification.notificationId)
+        assertThat(notificationMap.getString("titleText")).isEqualTo("Tap this")
+        assertThat(notificationMap.getString("subtitleText")).isEqualTo("Please")
+        assertThat(notificationMap.getString("contentText")).isEqualTo("We really want you to tap this notification")
+        assertThat(notificationMap.getString("actionToken")).isEqualTo(TEST_ACTION_TOKEN)
+        assertThat(notificationMap.getString("deepLinkUrl")).isEqualTo("snapyrsample://test/123")
+        assertThat(notificationMap.getString("imageUrl")).isEqualTo(
+            "https://images-na.ssl-images-amazon.com/images/S/pv" +
+                "-target-images/fb1fd46fbac48892ef9ba8c78f1eb6fa7d005de030b2a3d17b50581b2935832f._SX1080_.jpg"
+        )
     }
 
     @Test
@@ -112,6 +124,15 @@ class SnapyrNotificationTest {
         assertThat(snapyrNotification.actionToken).isEqualTo(TEST_ACTION_TOKEN)
         assertThat(snapyrNotification.deepLinkUrl).isNull()
         assertThat(snapyrNotification.imageUrl).isNull()
+
+        val notificationMap = snapyrNotification.asValueMap()
+        assertThat(notificationMap.getInt("notificationId", -1)).isEqualTo(snapyrNotification.notificationId)
+        assertThat(notificationMap.getString("titleText")).isEqualTo("Tap this")
+        assertThat(notificationMap.getString("subtitleText")).isNull()
+        assertThat(notificationMap.getString("contentText")).isEqualTo("We really want you to tap this notification")
+        assertThat(notificationMap.getString("actionToken")).isEqualTo(TEST_ACTION_TOKEN)
+        assertThat(notificationMap.getString("deepLinkUrl")).isNull()
+        assertThat(notificationMap.getString("imageUrl")).isNull()
     }
 
     @Test(expected = java.lang.IllegalArgumentException::class)

--- a/snapyr/src/test/java/com/snapyr/sdk/notifications/SnapyrNotificationTest.kt
+++ b/snapyr/src/test/java/com/snapyr/sdk/notifications/SnapyrNotificationTest.kt
@@ -1,0 +1,161 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Segment.io, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.snapyr.sdk.notifications
+
+import android.os.Bundle
+import com.google.firebase.messaging.RemoteMessage
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.whenever
+import com.snapyr.sdk.TestUtils
+import com.snapyr.sdk.ValueMap
+import com.snapyr.sdk.http.ConnectionFactory
+import com.snapyr.sdk.internal.SnapyrAction
+import com.snapyr.sdk.notifications.SnapyrNotification.NonSnapyrMessageException
+import com.snapyr.sdk.services.Cartographer
+import com.snapyr.sdk.services.ServiceFacade
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.util.concurrent.Semaphore
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito
+import org.mockito.Mockito.verify
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class SnapyrNotificationTest {
+    private val TEST_ACTION_TOKEN = "Zjk1OTkxZGEtZWE5Yy00ZTQ0LTk5OGQtNWZmNWY0Y2EwNGQzOmIyOWY5MDE4LWVhMjUtNGJmNS04YTliLWQ4ZDZhOGJjMjlhMTpmYmYxMTljMS1lMjNlLTQxZDEtODkyMi05MjE5M2RlNGRkODk6NGZjOGE5NGQtNGU0Zi00NTQ4LWE3NjYtMzM1NDY2YmViMzBjOnB1Ymxpc2g6NGY5YTA0NzMtYWY4OS00M2QyLWEyZTMtZmFiN2FkNmU0MzUyOnBhdWwxMTExYTp0YmQ6MTY2ODY0ODQzOTphY3Rpb25Ub2tlbi00ZjlhMDQ3My1hZjg5LTQzZDItYTJlMy1mYWI3YWQ2ZTQzNTIucGF1bDExMTFhLjE2Njg2NDg0Mzk="
+
+    @Test
+    @Throws(IOException::class)
+    fun testGoodNotification() {
+        val dataMap = HashMap<String, String>();
+        dataMap.set("snapyr", """
+            {
+                "title": "Tap this",
+                "subtitle": "Please",
+                "contentText": "We really want you to tap this notification",
+                "deepLinkUrl": "snapyrsample://test/123",
+                "imageUrl": "https://images-na.ssl-images-amazon.com/images/S/pv-target-images/fb1fd46fbac48892ef9ba8c78f1eb6fa7d005de030b2a3d17b50581b2935832f._SX1080_.jpg",
+                "pushTemplate": {
+                    "id": "b29f9018-ea25-4bf5-8a9b-d8d6a8bc29a1",
+                    "modified": "2022-11-10T21:20:15.409Z"
+                },
+                "actionToken": "Zjk1OTkxZGEtZWE5Yy00ZTQ0LTk5OGQtNWZmNWY0Y2EwNGQzOmIyOWY5MDE4LWVhMjUtNGJmNS04YTliLWQ4ZDZhOGJjMjlhMTpmYmYxMTljMS1lMjNlLTQxZDEtODkyMi05MjE5M2RlNGRkODk6NGZjOGE5NGQtNGU0Zi00NTQ4LWE3NjYtMzM1NDY2YmViMzBjOnB1Ymxpc2g6NGY5YTA0NzMtYWY4OS00M2QyLWEyZTMtZmFiN2FkNmU0MzUyOnBhdWwxMTExYTp0YmQ6MTY2ODY0ODQzOTphY3Rpb25Ub2tlbi00ZjlhMDQ3My1hZjg5LTQzZDItYTJlMy1mYWI3YWQ2ZTQzNTIucGF1bDExMTFhLjE2Njg2NDg0Mzk="
+            }
+        """.trimMargin());
+        val remoteMessage = RemoteMessage.Builder("fakefirebasetoken")
+            .setData(dataMap)
+            .build()
+        val snapyrNotification = SnapyrNotification(remoteMessage)
+
+        // test parcel/unparcel, then ensure values are correct on the unparceled/copied object
+        val bundle = Bundle()
+        bundle.putParcelable("snapyrNotification", snapyrNotification)
+        val unparceledNotification = bundle.getParcelable<SnapyrNotification>("snapyrNotification")
+
+        assertThat(unparceledNotification).isNotNull()
+        assertThat(unparceledNotification!!.notificationId).isGreaterThan(0)
+        assertThat(unparceledNotification!!.titleText).isEqualTo("Tap this")
+        assertThat(unparceledNotification!!.subtitleText).isEqualTo("Please")
+        assertThat(unparceledNotification!!.contentText).isEqualTo("We really want you to tap this notification")
+        assertThat(unparceledNotification!!.actionToken).isEqualTo(TEST_ACTION_TOKEN)
+        assertThat(unparceledNotification!!.deepLinkUrl.toString()).isEqualTo("snapyrsample://test/123")
+        assertThat(unparceledNotification!!.imageUrl).isEqualTo("https://images-na.ssl-images-amazon.com/images/S/pv-target-images/fb1fd46fbac48892ef9ba8c78f1eb6fa7d005de030b2a3d17b50581b2935832f._SX1080_.jpg")
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun testNotificationMissingOptionalFields() {
+        val dataMap = HashMap<String, String>();
+        dataMap.set("snapyr", """
+            {
+                "title": "Tap this",
+                "contentText": "We really want you to tap this notification",
+                "actionToken": "Zjk1OTkxZGEtZWE5Yy00ZTQ0LTk5OGQtNWZmNWY0Y2EwNGQzOmIyOWY5MDE4LWVhMjUtNGJmNS04YTliLWQ4ZDZhOGJjMjlhMTpmYmYxMTljMS1lMjNlLTQxZDEtODkyMi05MjE5M2RlNGRkODk6NGZjOGE5NGQtNGU0Zi00NTQ4LWE3NjYtMzM1NDY2YmViMzBjOnB1Ymxpc2g6NGY5YTA0NzMtYWY4OS00M2QyLWEyZTMtZmFiN2FkNmU0MzUyOnBhdWwxMTExYTp0YmQ6MTY2ODY0ODQzOTphY3Rpb25Ub2tlbi00ZjlhMDQ3My1hZjg5LTQzZDItYTJlMy1mYWI3YWQ2ZTQzNTIucGF1bDExMTFhLjE2Njg2NDg0Mzk="
+            }
+        """.trimMargin());
+        val remoteMessage = RemoteMessage.Builder("fakefirebasetoken")
+            .setData(dataMap)
+            .build()
+        val snapyrNotification = SnapyrNotification(remoteMessage)
+        assertThat(snapyrNotification).isNotNull()
+        assertThat(snapyrNotification.notificationId).isGreaterThan(0)
+        assertThat(snapyrNotification.titleText).isEqualTo("Tap this")
+        assertThat(snapyrNotification.subtitleText).isNull()
+        assertThat(snapyrNotification.contentText).isEqualTo("We really want you to tap this notification")
+        assertThat(snapyrNotification.actionToken).isEqualTo(TEST_ACTION_TOKEN)
+        assertThat(snapyrNotification.deepLinkUrl).isNull()
+        assertThat(snapyrNotification.imageUrl).isNull()
+    }
+
+    @Test(expected = java.lang.IllegalArgumentException::class)
+    @Throws(IOException::class)
+    fun testNotificationMissingRequiredField() {
+        val dataMap = HashMap<String, String>();
+        dataMap.set("snapyr", """
+            {
+                "subtitle": "Please",
+                "contentText": "We really want you to tap this notification",
+                "deepLinkUrl": "snapyrsample://test/123",
+                "imageUrl": "https://images-na.ssl-images-amazon.com/images/S/pv-target-images/fb1fd46fbac48892ef9ba8c78f1eb6fa7d005de030b2a3d17b50581b2935832f._SX1080_.jpg",
+                "pushTemplate": {
+                    "id": "b29f9018-ea25-4bf5-8a9b-d8d6a8bc29a1",
+                    "modified": "2022-11-10T21:20:15.409Z"
+                },
+                "actionToken": "Zjk1OTkxZGEtZWE5Yy00ZTQ0LTk5OGQtNWZmNWY0Y2EwNGQzOmIyOWY5MDE4LWVhMjUtNGJmNS04YTliLWQ4ZDZhOGJjMjlhMTpmYmYxMTljMS1lMjNlLTQxZDEtODkyMi05MjE5M2RlNGRkODk6NGZjOGE5NGQtNGU0Zi00NTQ4LWE3NjYtMzM1NDY2YmViMzBjOnB1Ymxpc2g6NGY5YTA0NzMtYWY4OS00M2QyLWEyZTMtZmFiN2FkNmU0MzUyOnBhdWwxMTExYTp0YmQ6MTY2ODY0ODQzOTphY3Rpb25Ub2tlbi00ZjlhMDQ3My1hZjg5LTQzZDItYTJlMy1mYWI3YWQ2ZTQzNTIucGF1bDExMTFhLjE2Njg2NDg0Mzk="
+            }
+        """.trimMargin());
+        val remoteMessage = RemoteMessage.Builder("fakefirebasetoken")
+            .setData(dataMap)
+            .build()
+        val snapyrNotification = SnapyrNotification(remoteMessage)
+    }
+
+    @Test(expected = NonSnapyrMessageException::class)
+    @Throws(IOException::class)
+    fun testNonSnapyrNotification() {
+        val dataMap = HashMap<String, String>();
+
+        dataMap.set("subtitle", "Please")
+        dataMap.set("contentText", "We really want you to tap this notification")
+        dataMap.set("deepLinkUrl", "snapyrsample://test/123")
+        dataMap.set("imageUrl", "https://images-na.ssl-images-amazon.com/images/S/pv-target-images/fb1fd46fbac48892ef9ba8c78f1eb6fa7d005de030b2a3d17b50581b2935832f._SX1080_.jpg")
+        dataMap.set("pushTemplate", """{
+            "id": "b29f9018-ea25-4bf5-8a9b-d8d6a8bc29a1",
+            "modified": "2022-11-10T21:20:15.409Z"
+        }""")
+        dataMap.set("actionToken", "Zjk1OTkxZGEtZWE5Yy00ZTQ0LTk5OGQtNWZmNWY0Y2EwNGQzOmIyOWY5MDE4LWVhMjUtNGJmNS04YTliLWQ4ZDZhOGJjMjlhMTpmYmYxMTljMS1lMjNlLTQxZDEtODkyMi05MjE5M2RlNGRkODk6NGZjOGE5NGQtNGU0Zi00NTQ4LWE3NjYtMzM1NDY2YmViMzBjOnB1Ymxpc2g6NGY5YTA0NzMtYWY4OS00M2QyLWEyZTMtZmFiN2FkNmU0MzUyOnBhdWwxMTExYTp0YmQ6MTY2ODY0ODQzOTphY3Rpb25Ub2tlbi00ZjlhMDQ3My1hZjg5LTQzZDItYTJlMy1mYWI3YWQ2ZTQzNTIucGF1bDExMTFhLjE2Njg2NDg0Mzk=")
+
+        val remoteMessage = RemoteMessage.Builder("fakefirebasetoken")
+            .setData(dataMap)
+            .build()
+        val snapyrNotification = SnapyrNotification(remoteMessage)
+    }
+}


### PR DESCRIPTION
## Push notification event broadcasts
Adds event broadcasts when Snapyr push notifications are received or tapped. A consumer can set up a broadcast receiver to listen to these and run custom code when a push notification event occurs. This enables callbacks in the React Native SDK, but could also be listened to directly by other Android code.

A lot of the code changes in this PR involve moving logic from `SnapyrNotificationListener` and `SnapyrFirebaseMessagingService` into a new class, `SnapyrNotification`. This is a structured representation of a notification object. It implements the Parcelable interface so that it can be passed around as part of an Intent, and reconstituted back to a full `SnapyrNotification` object on the receiving side.

## Debugging improvements
Updates the Gradle config to allow this project to be included as a local subproject, within another Gradle project. This facilitates development of React Native and other SDKs that use this SDK, without needing to perform a full build and `.aar` update after every code change.

This is optional, and doesn't change how to work with this project on its own.

## Bug fix
Incidental fix for a bug where only one notification for an app would remain in the notification drawer, if multiple notifications were received while the application is in a closed state, due to the notification ID counter getting reset to 0 each time.