### PR TITLE
Fix - text-only notifs expandable on some OSes

### DIFF
--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
@@ -128,7 +128,12 @@ public class SnapyrNotificationHandler {
                 .setContentTitle(snapyrNotification.titleText)
                 .setContentText(snapyrNotification.contentText)
                 .setSubText(snapyrNotification.subtitleText)
-                .setAutoCancel(true); // true means notification auto dismissed after tapping. TODO
+                .setAutoCancel(true) // true means notification auto dismissed after tapping
+                // Allows expansion of notifications with text overflow. Will optionally be
+                // overridden by BigPictureStyle later, if notification has rich media
+                .setStyle(
+                        new NotificationCompat.BigTextStyle()
+                                .bigText(snapyrNotification.contentText));
 
         Intent trackIntent = new Intent(applicationContext, SnapyrNotificationListener.class);
         trackIntent.putExtra("snapyr.notification", snapyrNotification);
@@ -171,7 +176,10 @@ public class SnapyrNotificationHandler {
             try {
                 inputStream = new URL(snapyrNotification.imageUrl).openStream();
                 image = BitmapFactory.decodeStream(inputStream);
-                builder.setStyle(new NotificationCompat.BigPictureStyle().bigPicture(image));
+                builder.setStyle(
+                        new NotificationCompat.BigPictureStyle()
+                                .bigPicture(image)
+                                .setSummaryText(snapyrNotification.contentText));
             } catch (Exception e) {
                 Log.e(
                         "Snapyr",


### PR DESCRIPTION
Some Android devices/OSes, including Google Pixel, automatically make long text notifications expandable, but others do not. In that case notifications with text that exceeds the width of the notification will have the text truncated with an ellipsis, with no way to expand the notification to see more.

Setting `BigTextStyle` ensures that notifications with longer text can be expanded.

This applies only to notifications that do not include an image. Notifs w/ image will override this with a `BigPictureStyle` which includes the image, and a length-limited summary text. Note that BigPictureStyle does NOT allow the text to be expanded, so notifs with images can only display the ellipsis-truncated text alongside the image.