### PR TITLE
Android N fixes

### DIFF
--- a/snapyr/src/main/java/com/snapyr/sdk/Snapyr.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/Snapyr.java
@@ -35,14 +35,12 @@ import android.content.pm.ActivityInfo;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.ProcessLifecycleOwner;
 import com.snapyr.sdk.http.BatchQueue;
@@ -220,7 +218,6 @@ public class Snapyr {
 
         analyticsExecutor.submit(
                 new Runnable() {
-                    @RequiresApi(api = Build.VERSION_CODES.O)
                     @Override
                     public void run() {
                         RefreshConfiguration(false);
@@ -455,7 +452,6 @@ public class Snapyr {
         }
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
     public void RefreshConfiguration(boolean force) {
         ProjectSettings newSettings = getSettings(force);
         if (!isNullOrEmpty(newSettings)) {

--- a/snapyr/src/main/java/com/snapyr/sdk/inapp/webview/WebviewModalView.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/inapp/webview/WebviewModalView.java
@@ -37,6 +37,7 @@ import android.view.Gravity;
 import android.view.View;
 import android.view.WindowManager;
 import android.webkit.WebView;
+import android.webkit.WebViewClient;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
@@ -173,8 +174,8 @@ public class WebviewModalView extends FrameLayout {
         WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
     }
 
-    private InAppWebviewClient createClient() {
-        return new InAppWebviewClient() {
+    private WebViewClient createClient() {
+        return new WebViewClient() {
             @Override
             public void onPageCommitVisible(WebView view, String url) {
                 super.onPageCommitVisible(view, url);

--- a/snapyr/src/main/java/com/snapyr/sdk/internal/PushTemplate.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/internal/PushTemplate.java
@@ -46,12 +46,7 @@ package com.snapyr.sdk.internal;
        ]
 */
 
-import android.os.Build;
-import androidx.annotation.RequiresApi;
 import com.snapyr.sdk.ValueMap;
-import java.time.Instant;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -68,14 +63,12 @@ public class PushTemplate {
     Date modified;
     ArrayList<ActionButton> buttons;
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
     public PushTemplate(Map<String, Object> src) {
         super();
         this.id = (String) src.get("id");
         String modifiedStr = (String) src.get("modified");
 
-        TemporalAccessor ta = DateTimeFormatter.ISO_INSTANT.parse(modifiedStr);
-        this.modified = Date.from(Instant.from(ta));
+        this.modified = Utils.parseISO8601Date(modifiedStr);
         this.buttons = new ArrayList<>();
 
         ArrayList<Map<String, Object>> buttonsRaw = (ArrayList) src.get("actions");
@@ -84,7 +77,6 @@ public class PushTemplate {
         }
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
     public static Map<String, PushTemplate> ParseTemplate(ValueMap metadata) {
         ArrayList<Map<String, Object>> templates =
                 (ArrayList<Map<String, Object>>) metadata.get("pushTemplates");

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrFirebaseMessagingService.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrFirebaseMessagingService.java
@@ -24,10 +24,8 @@
 package com.snapyr.sdk.notifications;
 
 import android.content.Intent;
-import android.os.Build;
 import android.util.Log;
 import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
 import com.snapyr.sdk.Snapyr;
@@ -50,7 +48,6 @@ public class SnapyrFirebaseMessagingService extends FirebaseMessagingService {
         }
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
     @Override
     public void onMessageReceived(RemoteMessage remoteMessage) {
         super.onMessageReceived(remoteMessage);
@@ -107,7 +104,6 @@ public class SnapyrFirebaseMessagingService extends FirebaseMessagingService {
         this.sendBroadcast(pushReceivedIntent);
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
     private PushTemplate processPushTemplate(
             @NonNull SnapyrNotification snapyrNotification, Snapyr sdkInstance) {
         if (snapyrNotification.templateId == null || snapyrNotification.templateModified == null) {

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
@@ -36,7 +36,6 @@ import android.graphics.BitmapFactory;
 import android.os.Build;
 import android.util.Log;
 import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 import com.google.android.gms.tasks.OnCompleteListener;
@@ -114,7 +113,6 @@ public class SnapyrNotificationHandler {
         }
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.N)
     public void showRemoteNotification(SnapyrNotification snapyrNotification) {
         registerChannel(
                 snapyrNotification.channelId,
@@ -218,14 +216,14 @@ public class SnapyrNotificationHandler {
         }
         if (result == 0) {
             // Nothing found yet; use the app's own launcher icon. Should always be set...
-            Log.d(
+            Log.w(
                     "Snapyr",
                     "SnapyrNotificationHandler: couldn't find notification icon; falling back to your app's launcher icon");
             result = applicationContext.getApplicationInfo().icon;
         }
         if (result == 0) {
             // ... if not, use an Android built-in icon guaranteed to be present (a bell)
-            Log.d(
+            Log.w(
                     "Snapyr",
                     "SnapyrNotificationHandler: couldn't find app's launcher icon; falling back to system icon");
             result = android.R.drawable.ic_popup_reminder;
@@ -268,7 +266,6 @@ public class SnapyrNotificationHandler {
         }
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
     public void showSampleNotification() {
         ArrayList<ValueMap> actionButtons = new ArrayList<>();
         actionButtons.add(

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
@@ -123,9 +123,15 @@ public class SnapyrNotificationHandler {
         NotificationCompat.Builder builder =
                 new NotificationCompat.Builder(this.context, snapyrNotification.channelId);
         builder.setSmallIcon(getNotificationIcon())
+                // only applies for Android N or older (ignored on later versions) - enables
+                // sound/vibration/lights, which helps make the "heads-up" notif preview display
+                .setDefaults(NotificationCompat.DEFAULT_ALL)
                 .setContentTitle(snapyrNotification.titleText)
                 .setContentText(snapyrNotification.contentText)
                 .setSubText(snapyrNotification.subtitleText)
+                // Android N or older - must be PRIORITY_HIGH or higher for "heads-up" notif preview
+                // to display
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
                 .setAutoCancel(true) // true means notification auto dismissed after tapping
                 // Allows expansion of notifications with text overflow. Will optionally be
                 // overridden by BigPictureStyle later, if notification has rich media


### PR DESCRIPTION
* Remove @RequiresApi; use util date parser 
    Minor update to use the existing date parser utility method in PushTemplate instead of newer Java utils, allowing removal of @RequiresApi decorators that prevent notifications from working on older Android versions
* Add settings to make notifications show heads-up preview on Android N + older
* Use plain WebViewClient (no override for now) 
    InAppWebviewClient `shouldOverrideUrlLoading` is currently unused, as the overlay script cancels clicks on <a> tags and sends event data to the SDK instead for handling.

    Existing code in InAppWebviewClient could cause error/crash if the overlay script doesn't work for some reason, so disabling it to be safe. We may want to update this and use again in the future, so leaving the class here