### PR TITLE
Notification safety

### DIFF
--- a/snapyr/src/main/java/com/snapyr/sdk/Snapyr.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/Snapyr.java
@@ -39,6 +39,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
+import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.Lifecycle;
@@ -1468,9 +1469,13 @@ public class Snapyr {
             return this;
         }
 
+        /** Snapyr internal use only - do not call */
         public Builder enableHelperInstance(Context ctx) {
-            if (ctx.getClass().getPackage() != SnapyrNotificationHandler.class.getPackage()) {
-                throw new IllegalAccessError("Snapyr internal use only");
+            if (!ctx.getClass()
+                    .getPackage()
+                    .getName()
+                    .equals(SnapyrNotificationHandler.class.getPackage().getName())) {
+                Log.e("Snapyr", "Snapyr internal use only - do not call");
             }
             this.isHelperInstance = true;
             return this;

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrFirebaseMessagingService.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrFirebaseMessagingService.java
@@ -50,8 +50,21 @@ public class SnapyrFirebaseMessagingService extends FirebaseMessagingService {
 
     @Override
     public void onMessageReceived(RemoteMessage remoteMessage) {
-        super.onMessageReceived(remoteMessage);
+        try {
+            super.onMessageReceived(remoteMessage);
+            handleMessageReceived(remoteMessage);
+        } catch (Exception e) {
+            Log.e(
+                    "Snapyr",
+                    "Notification service encountered an unexpected error while attempting to process and display an incoming push notification",
+                    e);
+        }
+    }
+
+    private void handleMessageReceived(RemoteMessage remoteMessage) {
         SnapyrNotification snapyrNotification;
+        Snapyr snapyrInstance;
+
         try {
             snapyrNotification = new SnapyrNotification(remoteMessage);
         } catch (SnapyrNotification.NonSnapyrMessageException e) {
@@ -63,11 +76,18 @@ public class SnapyrFirebaseMessagingService extends FirebaseMessagingService {
             return;
         }
 
-        Snapyr snapyrInstance = SnapyrNotificationUtils.getSnapyrInstance(this);
-        if (snapyrInstance == null) {
+        try {
+            snapyrInstance = SnapyrNotificationUtils.getSnapyrInstance(this);
+            if (snapyrInstance == null) {
+                Log.e(
+                        "Snapyr",
+                        "Notification service couldn't initialize Snapyr. Make sure you've initialized Snapyr from within your main application prior to receiving notifications.");
+                return;
+            }
+        } catch (Exception e) {
             Log.e(
                     "Snapyr",
-                    "Notification service couldn't initialize Snapyr. Make sure you've initialized Snapyr from within your main application prior to receiving notifications.");
+                    "Notification service encountered exception while initializing Snapyr. Make sure you've initialized Snapyr from within your main application prior to receiving notifications.");
             return;
         }
 


### PR DESCRIPTION
Moves the logic from messaging service `onMessageReceived` to another method, and wraps the entire call in a try/catch to ensure that any unexpected exceptions do not result in a crash.

Also includes a couple of more specific safety improvements.