### PR TITLE
Notification helper updates

### DIFF
--- a/snapyr/src/main/java/com/snapyr/sdk/Snapyr.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/Snapyr.java
@@ -39,7 +39,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
-import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.Lifecycle;
@@ -1234,7 +1233,7 @@ public class Snapyr {
         private boolean useNewLifecycleMethods = true; // opt-out feature
         private ConnectionFactory.Environment snapyrEnvironment =
                 ConnectionFactory.Environment.PROD;
-        private boolean isHelperInstance = false; // internal use only
+        protected boolean isHelperInstance = false; // internal use only
 
         /** Start building a new {@link Snapyr} instance. */
         public Builder(Context context, String writeKey) {
@@ -1466,18 +1465,6 @@ public class Snapyr {
         public Builder defaultProjectSettings(ValueMap defaultProjectSettings) {
             Utils.assertNotNull(defaultProjectSettings, "defaultProjectSettings");
             this.defaultProjectSettings = defaultProjectSettings;
-            return this;
-        }
-
-        /** Snapyr internal use only - do not call */
-        public Builder enableHelperInstance(Context ctx) {
-            if (!ctx.getClass()
-                    .getPackage()
-                    .getName()
-                    .equals(SnapyrNotificationHandler.class.getPackage().getName())) {
-                Log.e("Snapyr", "Snapyr internal use only - do not call");
-            }
-            this.isHelperInstance = true;
             return this;
         }
 

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/HelperSnapyrBuilder.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/HelperSnapyrBuilder.java
@@ -1,0 +1,50 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Segment.io, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.snapyr.sdk.notifications;
+
+import android.content.Context;
+import com.snapyr.sdk.Snapyr;
+
+class HelperSnapyrBuilder extends Snapyr.Builder {
+
+    /**
+     * Start building a new {@link Snapyr} instance.
+     *
+     * @param context
+     * @param writeKey
+     */
+    public HelperSnapyrBuilder(Context context, String writeKey) {
+        super(context, writeKey);
+    }
+
+    /**
+     * Sets this as a helper instance. When built, this parameter will cause the Snapyr instance to
+     * be created in a more minimal way so that notification tracking can be done while avoiding
+     * unnecessary processing.
+     */
+    public Snapyr.Builder enableHelperInstance(Context ctx) {
+        this.isHelperInstance = true;
+        return this;
+    }
+}

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationHandler.java
@@ -189,6 +189,14 @@ public class SnapyrNotificationHandler {
                         "Snapyr",
                         "SnapyrNotificationHandler: found imageUrl but unable to fetch or apply image",
                         e);
+            } finally {
+                try {
+                    if (inputStream != null) {
+                        inputStream.close();
+                    }
+                } catch (Exception e) {
+                    Log.w("Snapyr", "Error closing stream for notification image", e);
+                }
             }
         }
 

--- a/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationUtils.java
+++ b/snapyr/src/main/java/com/snapyr/sdk/notifications/SnapyrNotificationUtils.java
@@ -51,9 +51,9 @@ class SnapyrNotificationUtils {
         if (writeKey == null) {
             return null;
         }
-        return new Snapyr.Builder(context, writeKey)
-                .snapyrEnvironment(environment)
+        return new HelperSnapyrBuilder(context, writeKey)
                 .enableHelperInstance(context)
+                .snapyrEnvironment(environment)
                 .build();
     }
 }


### PR DESCRIPTION
Cleans up handling of internal-only call to `enableHelperInstance` by removing it from the main, public Snapyr class and moving to a subclass that is used by SnapyrNotificationUtils.

Also adds code to close the connection for rich notification image downloading after fetch is complete.